### PR TITLE
BeautifulSoup instead of minidom

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,11 @@ import sys
 if sys.version_info >= (3,):
     prereqs = []
 else:
-    prereqs = ['simplejson>=2.0.9', ]
+    prereqs = ['simplejson>=2.0.9', 'beautifulsoup4>=4.0.0', ]
 
 setup(
     name='pymediainfo',
-    version='1.3.5',
+    version='1.3.6',
     author='Patrick Altman',
     author_email='paltman@gmail.com',
     url='git@github.com/paltman/pymediainfo.git',


### PR DESCRIPTION
minidom is not very compliant with the (sometimes) invalid xml provided by mediainfo.

For example, minidom refuses the following xml countaining  '&#x01;', resulting in an empty MediaInfo.xml_dom

```
'<?xml version="1.0" encoding="UTF-8"?>\n<Mediainfo><track type="General">...\n<segm>&#x01;</segm>\n</track>\n\n</Mediainfo>\n\n'
```

replacing minidom by BeautifulSoup permits to deal with this movie (and with many more).

This commit:
replaces minidom by BeautifulSoup
adds beautifulsoup4 requirement
bumps version number from 1.3.5 to 1.3.6
