### PR TITLE
Use pipes instead of files while parsing.

### DIFF
--- a/pymediainfo/__init__.py
+++ b/pymediainfo/__init__.py
@@ -1,4 +1,4 @@
-from subprocess import Popen
+from subprocess import Popen, PIPE
 from bs4 import BeautifulSoup, NavigableString
 import os, sys
 from xml.parsers.expat import ExpatError
@@ -87,17 +87,11 @@ class MediaInfo(object):
     @staticmethod
     def parse(filename, environment=ENV_DICT):
         command = ["mediainfo", "-f", "--Output=XML", filename]
-        fileno_out, fname_out = mkstemp(suffix=".xml", prefix="media-")
-        fileno_err, fname_err = mkstemp(suffix=".err", prefix="media-")
-        fp_out = os.fdopen(fileno_out, 'r+b')
-        fp_err = os.fdopen(fileno_err, 'r+b')
-        p = Popen(command, stdout=fp_out, stderr=fp_err, env=environment)
+        p = Popen(command, stdout=PIPE, env=environment)
         p.wait()
-        fp_out.seek(0)
 
-        xml_dom = MediaInfo.parse_xml_data_into_dom(fp_out.read())
-        fp_out.close()
-        fp_err.close()
+        xml_dom = MediaInfo.parse_xml_data_into_dom(p.stdout.read())
+        p.stdout.close()
         return MediaInfo(xml_dom)
 
     def _populate_tracks(self):


### PR DESCRIPTION
When using this library for many files for a long time  the /tmp/ directory is being jammed with so much unused data. It's sad. So I propose to use pipes instead of temporary files to improve overall system performance.