### PR TITLE
Using TemporaryFile instead of mkstemp() and fix several broken tests

### DIFF
--- a/pymediainfo/__init__.py
+++ b/pymediainfo/__init__.py
@@ -85,8 +85,8 @@ class MediaInfo(object):
         command = ["mediainfo", "-f", "--Output=XML", filename]
         fileno_out, fname_out = mkstemp(suffix=".xml", prefix="media-")
         fileno_err, fname_err = mkstemp(suffix=".err", prefix="media-")
-        fp_out = os.fdopen(fileno_out, 'r+b')
-        fp_err = os.fdopen(fileno_err, 'r+b')
+        fp_out = os.fdopen(fileno_out, 'rb')
+        fp_err = os.fdopen(fileno_err, 'rb')
         p = Popen(command, stdout=fp_out, stderr=fp_err, env=environment)
         p.wait()
         fp_out.seek(0)

--- a/pymediainfo/__init__.py
+++ b/pymediainfo/__init__.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 from subprocess import Popen
-from tempfile import mkstemp
+from tempfile import TemporaryFile
 
 from bs4 import BeautifulSoup, NavigableString
 
@@ -83,19 +83,12 @@ class MediaInfo(object):
     @staticmethod
     def parse(filename, environment=ENV_DICT):
         command = ["mediainfo", "-f", "--Output=XML", filename]
-        fileno_out, fname_out = mkstemp(suffix=".xml", prefix="media-")
-        fileno_err, fname_err = mkstemp(suffix=".err", prefix="media-")
-        fp_out = os.fdopen(fileno_out, 'rb')
-        fp_err = os.fdopen(fileno_err, 'rb')
+        fp_out = TemporaryFile(suffix=".xml", prefix="media-")
+        fp_err = TemporaryFile(suffix=".err", prefix="media-")
         p = Popen(command, stdout=fp_out, stderr=fp_err, env=environment)
         p.wait()
         fp_out.seek(0)
-
         xml_dom = MediaInfo.parse_xml_data_into_dom(fp_out.read())
-        fp_out.close()
-        fp_err.close()
-        os.unlink(fname_out)
-        os.unlink(fname_err)
         return MediaInfo(xml_dom)
 
     def _populate_tracks(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 nose
 sphinx
+beautifulsoup4>=4.0.0

--- a/tests/data/invalid.xml
+++ b/tests/data/invalid.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Mediainfo>
 <File>
+<></Invalid tag>
 <track type="General">
 
 <Count>260</Count>
@@ -62,7 +63,6 @@
 <Writing_library>Apple QuickTime</Writing_library>
 <Writing_library>Apple QuickTime</Writing_library>
 <Writing_library_Name>Apple QuickTime</Writing_library_Name>
-<>00;05;34;23</>
 </track>
 
 <track type="Video">

--- a/tests/data/sample2.xml
+++ b/tests/data/sample2.xml
@@ -56,7 +56,6 @@
 <Tagged_date>UTC 2010-10-21 03:56:48</Tagged_date>
 <File_last_modification_date>UTC 2010-10-22 00:00:53</File_last_modification_date>
 <File_last_modification_date__local_>2010-10-21 19:00:53</File_last_modification_date__local_>
-<>00:00:00:00</>
 </track>
 
 <track type="Video">

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from xml.dom import minidom
+from bs4 import BeautifulSoup
 
 from pymediainfo import MediaInfo
 
@@ -9,16 +9,16 @@ from pymediainfo import MediaInfo
 class MediaInfoTest(unittest.TestCase):
 
     def setUp(self):
-        self.xml_data = open(os.path.join(os.path.dirname(__file__), 'data/sample.xml'), 'rb').read()
+        self.xml_data = open(os.path.join(os.path.dirname(__file__),
+                                          'data/sample.xml'), 'rb').read()
+        self.xml_dom = BeautifulSoup(self.xml_data, "xml")
 
     def test_populate_tracks(self):
-        xml = minidom.parseString(self.xml_data)
-        mi = MediaInfo(xml)
+        mi = MediaInfo(self.xml_dom)
         self.assertEqual(4, len(mi.tracks))
 
     def test_valid_video_track(self):
-        xml = minidom.parseString(self.xml_data)
-        mi = MediaInfo(xml)
+        mi = MediaInfo(self.xml_dom)
         for track in mi.tracks:
             if track.track_type == 'Video':
                 self.assertEqual('DV', track.codec)
@@ -26,8 +26,7 @@ class MediaInfoTest(unittest.TestCase):
                 break
 
     def test_track_integer_attributes(self):
-        xml = minidom.parseString(self.xml_data)
-        mi = MediaInfo(xml)
+        mi = MediaInfo(self.xml_dom)
         for track in mi.tracks:
             if track.track_type == 'Audio':
                 self.assertTrue(isinstance(track.duration, int))
@@ -36,8 +35,7 @@ class MediaInfoTest(unittest.TestCase):
                 break
 
     def test_track_other_attributes(self):
-        xml = minidom.parseString(self.xml_data)
-        mi = MediaInfo(xml)
+        mi = MediaInfo(self.xml_dom)
         for track in mi.tracks:
             if track.track_type == 'General':
                 self.assertEqual(5, len(track.other_file_size))
@@ -56,7 +54,8 @@ class MediaInfoTest(unittest.TestCase):
 class MediaInfoInvalidXML2Test(unittest.TestCase):
 
     def setUp(self):
-        self.xml_data = open(os.path.join(os.path.dirname(__file__), 'data/sample2.xml'), 'rb').read()
+        self.xml_data = open(os.path.join(os.path.dirname(__file__),
+                                          'data/sample2.xml'), 'rb').read()
 
     def test_populate_tracks(self):
         mi = MediaInfo(self.xml_data)
@@ -87,11 +86,11 @@ class MediaInfoInvalidXML2Test(unittest.TestCase):
         self.assertTrue(mi.tracks[0].does_not_exist is None)
 
 
-
 class MediaInfoInvalidXMLTest(unittest.TestCase):
 
     def setUp(self):
-        self.xml_data = open(os.path.join(os.path.dirname(__file__), 'data/invalid.xml'), 'rb').read()
+        self.xml_data = open(os.path.join(os.path.dirname(__file__),
+                                          'data/invalid.xml'), 'rb').read()
 
     def test_parse_invalid_xml(self):
         mi = MediaInfo(MediaInfo.parse_xml_data_into_dom(self.xml_data))


### PR DESCRIPTION
Hi, 

Please review my changes.

Note that changes has a collision with https://github.com/paltman/pymediainfo/pull/11. I think PR https://github.com/paltman/pymediainfo/pull/11 is more likely, but you decide.

Also changes fix some test, which had been broken when migration onto beautifulsoap4 was done.

Thanks!

