### PR TITLE
add missing install_requires dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     license='MIT',
+    install_requires=['pkg_resources'],
     tests_require=["pytest", "pytest-runner"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
This was first reported in Debian bug [#896313][] which says that, in
a clean environment, pymediainfo will fail to run because it is
missing pkg_resources. This can happen if it is installed from
`setup.py` without going through pip, for example.

 [#896313]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=896313