### PR TITLE
Allow pickling of Track objects

### DIFF
--- a/pymediainfo/__init__.py
+++ b/pymediainfo/__init__.py
@@ -54,6 +54,10 @@ class Track(object):
         except:
             pass
         return None
+    def __getstate__(self):
+        return self.__dict__
+    def __setstate__(self, state):
+        self.__dict__ = state
     def __init__(self, xml_dom_fragment):
         self.xml_dom_fragment = xml_dom_fragment
         self.track_type = xml_dom_fragment.attrib['type']


### PR DESCRIPTION
The Track class is incompatible with the pickle module because of the magic `__getattribute__` override, resulting in
```
TypeError: 'NoneType' object is not callable
```
error when unpickling (in Python 3 for example, pickle tries to get the object's `__reduce_ex__()` function and then call it).

This PR fixes it by implementing trivial `__getstate__` and `__setstate__` pickle protocol support that simply uses `__dict__` for the state.

At the risk of stating the obvious, pickling support can be useful e.g. when caching mediainfo output.