### PR TITLE
Close and delete handle on MediaInfor error

### DIFF
--- a/pymediainfo/__init__.py
+++ b/pymediainfo/__init__.py
@@ -304,6 +304,8 @@ class MediaInfo(object):
             for option_name, option_value in mediainfo_options.items():
                 lib.MediaInfo_Option(handle, option_name, option_value)
         if lib.MediaInfo_Open(handle, filename) == 0:
+            lib.MediaInfo_Close(handle)
+            lib.MediaInfo_Delete(handle)
             raise RuntimeError("An eror occured while opening {}"
                     " with libmediainfo".format(filename))
         output = lib.MediaInfo_Inform(handle, 0)


### PR DESCRIPTION
Close and delete `libmediainfo` handle on error.

Closes #79 