### PR TITLE
Remove unused setuptools from setup.py. Fixes #92

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(
     data_files=data_files,
     use_scm_version=True,
     setup_requires=["setuptools_scm"],
-    install_requires=["setuptools"],
     tests_require=["pytest", "pytest-runner"],
     package_data={'pymediainfo': bin_files},
     cmdclass=cmdclass,


### PR DESCRIPTION
It can be slightly dangerous: if a tool (like pip-compile) pin
sub-dependency of a project depending on pymediainfo, it will lead to
setuptools version being pinned, which could soon conflict with pip.