### PR TITLE
Use importlib.metadata on python3.8+ and importlib_metadata for 3.6,3.7

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,10 @@ import os
 import subprocess
 import sys
 
-import pkg_resources
+try:
+    from importlib.metadata import version  # noqa
+except ImportError:
+    from importlib_metadata import version  # noqa
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -66,7 +69,7 @@ author = 'Patrick Altman, Louis Sautier'
 # the repository hasn't been changed prior to installation).
 # https://github.com/pypa/setuptools_scm#usage-from-sphinx
 if os.environ.get("READTHEDOCS") == "True":
-    version = pkg_resources.get_distribution(project).version
+    version = version(project)
 else:
     # The project root is the parent directory
     root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/pymediainfo/__init__.py
+++ b/pymediainfo/__init__.py
@@ -12,12 +12,15 @@ import warnings
 import xml.etree.ElementTree as ET
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pkg_resources import DistributionNotFound, get_distribution
+try:
+    from importlib.metadata import version, PackageNotFoundError  # noqa
+except ImportError:
+    from importlib_metadata import version, PackageNotFoundError  # noqa
 
 try:
-    __version__ = get_distribution("pymediainfo").version
-except DistributionNotFound:
-    pass
+    __version__ = version("pymediainfo")
+except PackageNotFoundError:
+    __version__ = ''
 
 
 class Track:

--- a/pymediainfo/__init__.py
+++ b/pymediainfo/__init__.py
@@ -20,7 +20,7 @@ except ImportError:
 try:
     __version__ = version("pymediainfo")
 except PackageNotFoundError:
-    __version__ = ''
+    __version__ = ""
 
 
 class Track:

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     use_scm_version=True,
     python_requires=">=3.6",
     setup_requires=["setuptools_scm"],
-    install_requires=["setuptools"],
+    install_requires=['importlib_metadata; python_version<"3.8"'],
     package_data={'pymediainfo': bin_files},
     cmdclass=cmdclass,
     classifiers=[


### PR DESCRIPTION
This removes the dependancy of setuptools for those of us using pyproject.toml and tools such as poetry and flit.

Signed-off-by: miigotu <miigotu@gmail.com>