### PR TITLE
Add libmediainfo.so to library_paths for Linux (actually Termux)

### DIFF
--- a/pymediainfo/__init__.py
+++ b/pymediainfo/__init__.py
@@ -283,7 +283,7 @@ class MediaInfo:
         elif sys.platform == "darwin":
             library_paths = ("libmediainfo.0.dylib", "libmediainfo.dylib")
         else:
-            library_paths = ("libmediainfo.so.0",)
+            library_paths = ("libmediainfo.so.0", "libmediainfo.so")
         script_dir = os.path.dirname(__file__)
         # Look for the library file in the script folder
         for library in library_paths:


### PR DESCRIPTION
The [libmediainfo](https://github.com/termux/termux-packages/tree/master/packages/libmediainfo) package of Termux uses `libmediainfo.so` rather than `libmediainfo.so.0`.