### PR TITLE
Publish wheel for macos-arm64, manylinux-x86_64 and manylinux-arm64

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -162,9 +162,9 @@ for:
       sudo dpkg -i "${libzen_deb}" "${mediainfo_deb}"
       popd
     fi
-    curl https://mediaarea.net/download/binary/libmediainfo0/${MEDIAINFO_VERSION}/MediaInfo_DLL_${MEDIAINFO_VERSION}_Lambda_x86_64.zip
+    curl -O https://mediaarea.net/download/binary/libmediainfo0/${MEDIAINFO_VERSION}/MediaInfo_DLL_${MEDIAINFO_VERSION}_Lambda_x86_64.zip
     unzip MediaInfo_DLL_*_x86_64.zip -d x86_64
-    curl https://mediaarea.net/download/binary/libmediainfo0/${MEDIAINFO_VERSION}/MediaInfo_DLL_${MEDIAINFO_VERSION}_Lambda_arm64.zip
+    curl -O https://mediaarea.net/download/binary/libmediainfo0/${MEDIAINFO_VERSION}/MediaInfo_DLL_${MEDIAINFO_VERSION}_Lambda_arm64.zip
     unzip MediaInfo_DLL_*_arm64.zip -d arm64
   build: off
   test_script: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -127,7 +127,8 @@ for:
       mv MediaInfoLib/libmediainfo.0.dylib pymediainfo
       mv MediaInfoLib/License.html docs
       pip install twine wheel
-      python setup.py bdist_wheel
+      _PYTHON_HOST_PLATFORM=macosx-10.10-x86_64 ARCHFLAGS='-arch x86_64' python setup.py bdist_wheel
+      _PYTHON_HOST_PLATFORM=macosx-11-universal2 ARCHFLAGS='-arch arm64 -arch x86_64' python setup.py bdist_wheel
       twine upload --skip-existing dist/*.whl
     fi
 -
@@ -161,6 +162,10 @@ for:
       sudo dpkg -i "${libzen_deb}" "${mediainfo_deb}"
       popd
     fi
+    curl https://mediaarea.net/download/binary/libmediainfo0/${MEDIAINFO_VERSION}/MediaInfo_DLL_${MEDIAINFO_VERSION}_Lambda_x86_64.zip
+    unzip MediaInfo_DLL_*_x86_64.zip -d x86_64
+    curl https://mediaarea.net/download/binary/libmediainfo0/${MEDIAINFO_VERSION}/MediaInfo_DLL_${MEDIAINFO_VERSION}_Lambda_arm64.zip
+    unzip MediaInfo_DLL_*_arm64.zip -d arm64
   build: off
   test_script: |
     if [[ $TOXENV =~ doc.* ]]; then
@@ -174,6 +179,13 @@ for:
     set -eo pipefail
     if [[ $APPVEYOR_REPO_TAG == "true" && $TOXENV == $DEPLOY_TOXENV ]]; then
       pip install twine
+      # source distribution
       python setup.py sdist
-      twine upload --skip-existing dist/*.gz
+      mv x86_64/LICENSE docs
+      # wheel x86_64
+      mv x86_64/lib/libmediainfo.so.0.0.0 pymediainfo/libmediainfo.so.0
+      _PYTHON_HOST_PLATFORM=manylinux_2_34_x86_64 ARCHFLAGS="-arch x86_64" python setup.py bdist_wheel
+      mv -f arm64/lib/libmediainfo.so.0.0.0 pymediainfo/libmediainfo.so.0
+      _PYTHON_HOST_PLATFORM=manylinux_2_34_arm64 ARCHFLAGS="-arch arm64" python setup.py bdist_wheel
+      twine upload --skip-existing dist/*.gz dist/*.whl
     fi

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,3 @@ test = pytest
 
 [tool:pytest]
 addopts = -vv -r a
-
-[bdist_wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,36 +1,56 @@
 #!/usr/bin/env python
 import os
 
-from setuptools import find_packages, setup
+from setuptools import find_packages, setup, Distribution
 
 with open("README.rst") as f:
     long_description = f.read()
 
+# Add license if it exists
 data_files = []
-bin_files = []
-cmdclass = {}
+bin_licenses = ['docs/License.html', 'docs/LICENSE']
+for bin_license in bin_licenses:
+    if os.path.exists(bin_license):
+        data_files.append(('docs', [bin_license]))
 
-bin_license = 'docs/License.html'
-if os.path.exists(bin_license):
-    data_files.append(('docs', [bin_license]))
-    bin_files.extend(['MediaInfo.dll', 'libmediainfo.*'])
-    try:
-        from wheel.bdist_wheel import bdist_wheel
+# Add libraries
+bin_files = ['MediaInfo.dll', 'libmediainfo.*']
+try:
+    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
-        class platform_bdist_wheel(bdist_wheel):
-            def finalize_options(self):
-                bdist_wheel.finalize_options(self)
-                # Force the wheel to be marked as platform-specific
-                self.root_is_pure = False
-            def get_tag(self):
-                python, abi, plat = bdist_wheel.get_tag(self)
-                # The python code works for any Python version,
-                # not just the one we are running to build the wheel
-                return 'py3', 'none', plat
+    class platform_bdist_wheel(_bdist_wheel):
+        def finalize_options(self):
+            _bdist_wheel.finalize_options(self)
+            # Force the wheel to be marked as platform-specific
+            self.root_is_pure = False
 
-        cmdclass['bdist_wheel'] = platform_bdist_wheel
-    except ImportError:
-        pass
+        def get_tag(self):
+            python, abi, plat = _bdist_wheel.get_tag(self)
+            # The python code works for any Python version,
+            # not just the one we are running to build the wheel
+            return 'py3', 'none', plat
+
+    # https://stackoverflow.com/questions/76450587/python-wheel-that-includes-shared-library-is-built-as-pure-python-platform-indep
+    class PlatformDistribution(Distribution):
+
+        def __init__(self, *attrs):
+            Distribution.__init__(self, *attrs)
+            self.cmdclass['bdist_wheel'] = platform_bdist_wheel
+
+        def is_pure(self):
+            return False
+
+        def has_ext_modules(self):
+            return True
+
+except ImportError:
+    class PlatformDistribution(Distribution):
+        def is_pure(self):
+            return False
+
+        def has_ext_modules(self):
+            return True
+
 
 setup(
     name='pymediainfo',
@@ -54,7 +74,7 @@ setup(
     setup_requires=["setuptools_scm"],
     install_requires=["importlib_metadata; python_version < '3.8'"],
     package_data={'pymediainfo': bin_files},
-    cmdclass=cmdclass,
+    distclass=PlatformDistribution,
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
fixes #127, #128

Taking inspiration from:

https://github.com/shakfu/cyfaust/blob/main/docs/devnotes/universal2.md

https://stackoverflow.com/questions/76450587/python-wheel-that-includes-shared-library-is-built-as-pure-python-platform-indep

I checked `manylinux-x86_64` was correct with [auditwheel](https://github.com/pypa/auditwheel), maybe checking with `auditwheel` could be added to the `tox` config or to the `appveyor` config.