### PR TITLE
Bundled wheels: update hashes automatically

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -85,29 +85,15 @@ for:
     - "SET PATH=%PYTHON%;%PYTHON%/Scripts;%PATH%"
     - "python --version"
     - "pip install pdm tox"
-    - "pdm install --no-self"
+    - "pdm install -v --dev --no-self"
   build_script:
     - ps: |
         if ($env:PYTHON.EndsWith('-x64')) {
           $pdm_arch = 'x86_64'
-          $mediainfo_arch = 'x64'
-          $expected_hash = '86e915c2eb14a78b90806fdb51738e745c3f657788078b3398eb857e7ffa2a9cdd19d69f448d9f07842bb45b53f2c77ac9ef516df1adc2a967a1f1df05c621e7'
         } else {
           $pdm_arch = 'i386'
-          $mediainfo_arch = 'i386'
-          $expected_hash = '704d3e36cf7a59ca447aed415fab8c39e8037ba527b96fcc4d5dcc0faba04be0f51d7938d61ae935d78a7b25f19bfb6fce1b406621650fb3bcc386d56c805752'
         }
-        # cURL is required for test_parse_url
-        $MEDIAINFO_VERSION = '24.12'
-        $file = "MediaInfo_CLI_${MEDIAINFO_VERSION}_Windows_${mediainfo_arch}.zip"
-        Start-FileDownload "https://mediaarea.net/download/binary/mediainfo/${MEDIAINFO_VERSION}/${file}"
-        $hash = (Get-FileHash "${file}" -Algorithm SHA512).Hash
-        if ($hash -ne $expected_hash) {
-          Write-Error "Hash mismatch for ${file}: expected ${expected_hash}, got ${hash}"
-          exit 1
-        }
-        unzip -o "${file}" LIBCURL.DLL
-        pdm run "build_win32_${pdm_arch}"
+        pdm run build_wheel -p win32 -a "${pdm_arch}"
         # Install the wheel we created
         Get-ChildItem dist/*.whl | ForEach-Object { pip install $_.FullName }
   test_script:
@@ -128,10 +114,11 @@ for:
     source "${HOME}/venv${PYTHON_VERSION}/bin/activate"
     python --version
     pip install pdm tox
-    pdm install --no-self
+    pdm install -v --dev --no-self
   build_script: |
     set -eo pipefail
-    pdm run build_darwin
+    # The wheel works for both arm64 and x86_64
+    pdm run build_wheel -p darwin -a arm64
     # Install the wheel we created
     pip install dist/*.whl
   test_script:
@@ -161,25 +148,20 @@ for:
     python --version
     # "python -m pip" will work with the unpacked PyPy too, "pip" won't
     python -m pip install pdm tox
-    pdm install --no-self
+    pdm install -v --dev --no-self
   build_script: |
     set -eo pipefail
     # Build the source distribution (sdist) first, this way we make sure it
     # won't contain libmediainfo.so.0 which we download later
     pdm build -v --no-wheel
     # Each pdm build clears the "dist" folder and we need to keep all the
-    # created files to upload them at a later stage
-    mkdir dist_files
-    mv -v dist/*.gz dist_files/
+    # created files to upload them at a later stage, use build_wheel_no_clean
     # wheel for arm64
-    pdm run build_linux_arm64
-    mv -v dist/*.whl dist_files/
+    pdm run build_wheel_no_clean -p linux -a arm64
     # wheel for x86_64
-    pdm run build_linux_x86_64
-    # Install the wheel we created
-    pip install dist/*.whl
-    # Move back the arm64 and source distributions to "dist"
-    mv -v dist_files/* dist/
+    pdm run build_wheel_no_clean -p linux -a x86_64
+    # Install the x86_64 wheel we created
+    pip install dist/*x86_64.whl
   test_script: |
     # We want to see the progression of the tests so we can't run
     # tox environments in parallel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # https://packaging.python.org/en/latest/specifications/pyproject-toml/
 [build-system]
-requires = ["pdm-backend", "wheel>=0.42"]
+requires = ["pdm-backend>=2.1", "wheel>=0.44"]
 build-backend = "pdm.backend"
 
 [project]
@@ -58,12 +58,72 @@ Documentation = "https://pymediainfo.readthedocs.io/"
 Bugs = "https://github.com/sbraz/pymediainfo/issues"
 
 
+# Custom entries for downloading the bundled libmediainfo
+[tool.bundled_libmediainfo]
+version = "24.12"
+
+[[tool.bundled_libmediainfo.wheel]]
+tag = "manylinux_2_27_x86_64"
+platform = "linux"
+arch = "x86_64"
+blake2b_sums = "13c4afb2948187cc06f13b1cd7d7a49f8618b8d1e3a440d9e96ef7b486a653d5e2567aae97dc253e3d3f484a7837e4b5a972abab4803223300a79c601c0bcce1"
+
+[[tool.bundled_libmediainfo.wheel]]
+tag = "manylinux_2_27_aarch64"
+platform = "linux"
+arch = "arm64"
+blake2b_sums = "4e5a9826fa987f4bde46a6586894d45f3d5381f25d8886dfef67f5db3a9f4377ecafc12acc6e2d71e43b062b686c2db2523052a1f3dd7505a41091847788d114"
+
+[[tool.bundled_libmediainfo.wheel]]
+tag = "macosx_10_10_universal2"
+platform = "darwin"
+# The same file is used for darwin x86_64 and arm64 (suffixed Mac_x86_64+arm64.tar.bz2)
+arch = "arm64"
+blake2b_sums = "65b8195f0859369fa0ab1870cbde1535bb57f16bde451b22585d849c870f1ca92972328c11edd15b6f8187445dd58efff7107cfce39d2be7a88e8c434589b4ae"
+
+[[tool.bundled_libmediainfo.wheel]]
+tag ="win_amd64"
+platform = "win32"
+arch = "x86_64"
+blake2b_sums = "f831c588e9eaf51201b4cc7995dce66852591764fc5ef05effd3a8a2037ff5d37ec039eef5d1f990f05bd7452c1cad720e95b77a095f9f1a690689e351fc00b8"
+
+[[tool.bundled_libmediainfo.wheel]]
+tag = "win32"
+platform = "win32"
+arch = "i386"
+blake2b_sums = "0f0e14c103eac858fe683ec7d51634d62e5e0af658940fd26608249f1048846a92a334438204fe5ecfceb70cb00e5550bfb717a77f10816a2583b5041bb61790"
+
+[[tool.bundled_libmediainfo.wheel]]
+tag = "win_arm64"
+platform = "win32"
+arch = "arm64"
+blake2b_sums = "e9f426f2e873f65ca1fdede5f8eb6dc3e871e682b821ad3f62acb1428eda5a27ce363f77a2c621d1b15f8e9b94976a10afb56fc069325ca7ba4efad14df03105"
+
+[[tool.bundled_libmediainfo.wheel]]
+cli_source = true
+platform = "win32"
+arch = "x86_64"
+blake2b_sums = "6b47901f5b132bb666d7786f2d103b88359a01a4eeaad35f7e36d90f5b289a2685a108daab0cb2baed0cfc50e2f993443a42b232b1287985f06ca29908412e93"
+
+[[tool.bundled_libmediainfo.wheel]]
+cli_source = true
+platform = "win32"
+arch = "i386"
+blake2b_sums = "e4c0ed6a87beab6ff28e77f2b5e91afb6f5a7a58ab5dc0aa1b8c038123b35f30ec55473787e54173905bbcfff0391d8845176db6847b1c3b96a7c6575bdd9619"
+
+[[tool.bundled_libmediainfo.wheel]]
+cli_source = true
+platform = "win32"
+arch = "arm64"
+blake2b_sums = "c6c58fca40a4f2aa03fee39909ad8e7bf1b35b1f55577088d49c0cd54d822b1f2985976a9aabd158c0ac7c8af5fd96f36154c1dfadc17283e518b3c204b97e63"
+
+
 # https://pdm-project.org/latest/
 [tool.pdm.version]
 source = "scm"
 
 [tool.pdm.dev-dependencies]
-download_library = ["wheel>=0.44", "requests"]
+download_library = ["wheel>=0.44", "requests", "tomlkit"]
 
 [tool.pdm.build]
 source-includes = ["docs/", "scripts/", "tests/"]
@@ -99,58 +159,40 @@ cmd = "python scripts/download_library.py -c"
 help = "Tag the wheels for a specific platform"
 cmd = "python scripts/tag_pure_wheels.py"
 
-[tool.pdm.scripts.build_linux_x86_64]
-help = "Build wheel with bundled library for Linux x86_64"
+[tool.pdm.scripts.update_checksums]
+help = "Update MediaInfo version and/or checksums in pyproject.toml"
+cmd = "python scripts/update_checksums.py {args}"
+
+[tool.pdm.scripts.build_wheel]
+help = "Build wheel with bundled library"
 composite = [
-  "download_library -c -p linux -a x86_64",
-  "pdm build -v --no-sdist",
-  "tag_wheel manylinux_2_27_x86_64",
+  "download_library -c {args}",
+  "{pdm} build -v --no-sdist",
+  "tag_wheel {args}",
 ]
 
-[tool.pdm.scripts.build_linux_arm64]
-help = "Build wheel with bundled library for Linux arm64"
+[tool.pdm.scripts.build_wheel_no_clean]
+help = "Build wheel with bundled library"
 composite = [
-  "download_library -c -p linux -a arm64",
-  "pdm build -v --no-sdist",
-  "tag_wheel manylinux_2_27_aarch64",
-]
-
-[tool.pdm.scripts.build_win32_x86_64]
-help = "Build wheel with bundled library for Windows x64"
-composite = [
-  "download_library -c -p win32 -a x86_64",
-  "pdm build -v --no-sdist",
-  "tag_wheel win_amd64",
-]
-
-[tool.pdm.scripts.build_win32_i386]
-help = "Build wheel with bundled library for Windows x32"
-composite = [
-  "download_library -c -p win32 -a i386",
-  "pdm build -v --no-sdist",
-  "tag_wheel win32",
-]
-
-[tool.pdm.scripts.build_darwin]
-help = "Build wheel with bundled library for MacOS x86_64 and arm64"
-composite = [
-  # -a doesn't matter as the file works with both x86_64 and arm64 (Mac_x86_64+arm64.tar.bz2)
-  "download_library -c -p darwin -a arm64",
-  "pdm build -v --no-sdist",
-  "tag_wheel macosx_10_10_universal2",
+  "download_library -c {args}",
+  "{pdm} build -v --no-clean --no-sdist",
+  "tag_wheel {args}",
 ]
 
 [tool.pdm.scripts.build_all]
 help = "Build all the wheels with bundled library and the sdist and wheel without library"
 composite = [
-  "build_linux_arm64",
-  "build_linux_x86_64",
-  "build_win32_x86_64",
-  "build_win32_i386",
-  "build_darwin",
-  # remove any library before building sdist and barebone wheel
+  # build sdist, clean dist
+  "{pdm} build -v --no-wheel",
+  "build_wheel_no_clean -p linux -a arm64",
+  "build_wheel_no_clean -p linux -a x86_64",
+  "build_wheel_no_clean -p win32 -a arm64",
+  "build_wheel_no_clean -p win32 -a x86_64",
+  "build_wheel_no_clean -p win32 -a i386",
+  "build_wheel_no_clean -p darwin -a arm64",
+  # remove any library before building barebone wheel
   "clean_library",
-  "pdm build",
+  "{pdm} build -v --no-sdist --no-clean",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,24 +99,6 @@ platform = "win32"
 arch = "arm64"
 blake2b_sums = "e9f426f2e873f65ca1fdede5f8eb6dc3e871e682b821ad3f62acb1428eda5a27ce363f77a2c621d1b15f8e9b94976a10afb56fc069325ca7ba4efad14df03105"
 
-[[tool.bundled_libmediainfo.wheel]]
-cli_source = true
-platform = "win32"
-arch = "x86_64"
-blake2b_sums = "6b47901f5b132bb666d7786f2d103b88359a01a4eeaad35f7e36d90f5b289a2685a108daab0cb2baed0cfc50e2f993443a42b232b1287985f06ca29908412e93"
-
-[[tool.bundled_libmediainfo.wheel]]
-cli_source = true
-platform = "win32"
-arch = "i386"
-blake2b_sums = "e4c0ed6a87beab6ff28e77f2b5e91afb6f5a7a58ab5dc0aa1b8c038123b35f30ec55473787e54173905bbcfff0391d8845176db6847b1c3b96a7c6575bdd9619"
-
-[[tool.bundled_libmediainfo.wheel]]
-cli_source = true
-platform = "win32"
-arch = "arm64"
-blake2b_sums = "c6c58fca40a4f2aa03fee39909ad8e7bf1b35b1f55577088d49c0cd54d822b1f2985976a9aabd158c0ac7c8af5fd96f36154c1dfadc17283e518b3c204b97e63"
-
 
 # https://pdm-project.org/latest/
 [tool.pdm.version]

--- a/scripts/download_library.py
+++ b/scripts/download_library.py
@@ -22,10 +22,10 @@ import requests
 script_folder = Path(__file__).resolve().parent
 sys.path.append(str(script_folder))
 
-from mediainfo_config import get_version_and_bundle_info  # noqa: E402
+from mediainfo_config import get_current_platform_and_arch, get_version_and_bundle_info  # noqa: E402
 
 if TYPE_CHECKING:
-    from typing import Literal
+    from mediainfo_config import Architecture, Platform
 
 
 #: Base URL for downloading MediaInfo library
@@ -49,10 +49,10 @@ class Downloader:
     version: str
 
     #: Platform of the bundled MediaInfo library
-    platform: Literal["linux", "darwin", "win32"]
+    platform: Platform
 
     #: Architecture of the bundled MediaInfo library
-    arch: Literal["x86_64", "arm64", "i386"]
+    arch: Architecture
 
     #: BLAKE2b hash of the downloaded MediaInfo library
     checksums: str | None = None
@@ -271,8 +271,8 @@ class Downloader:
 def download_files(
     folder: os.PathLike[str] | str,
     version: str,
-    platform: Literal["linux", "darwin", "win32"],
-    arch: Literal["x86_64", "arm64", "i386"],
+    platform: Platform,
+    arch: Architecture,
     *,
     checksums: str | None = None,
     timeout: int = 20,
@@ -291,8 +291,8 @@ def download_files(
 
 def get_file_hashes(
     version: str,
-    platform: Literal["linux", "darwin", "win32"],
-    arch: Literal["x86_64", "arm64", "i386"],
+    platform: Platform,
+    arch: Architecture,
     *,
     timeout: int = 20,
     verbose: bool = True,
@@ -398,8 +398,6 @@ def make_parser() -> argparse.ArgumentParser:
 
 
 if __name__ == "__main__":
-    import platform
-
     parser = make_parser()
     args = parser.parse_args()
 
@@ -410,8 +408,7 @@ if __name__ == "__main__":
         parser.error(f"{args.folder} does not exist or is not a folder")
 
     if args.auto:
-        args.platform = platform.system().lower()
-        args.arch = platform.machine().lower()
+        args.platform, args.arch = get_current_platform_and_arch()
 
     # Clean folder
     if args.clean:

--- a/scripts/download_library.py
+++ b/scripts/download_library.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import argparse
 import hashlib
 import os
 import shutil
@@ -18,31 +19,23 @@ from zipfile import ZipFile
 
 import requests
 
+script_folder = Path(__file__).resolve().parent
+sys.path.append(str(script_folder))
+
+from mediainfo_config import get_version_and_bundle_info  # noqa: E402
+
 if TYPE_CHECKING:
     from typing import Literal
 
 
 #: Base URL for downloading MediaInfo library
-BASE_URL: str = "https://mediaarea.net/download/binary/libmediainfo0"
+BASE_URL_LIB: str = "https://mediaarea.net/download/binary/libmediainfo0"
 
-#: Version of the bundled MediaInfo library
-MEDIAINFO_VERSION: str = "24.12"
-
-# fmt: off
-#: BLAKE2b hashes for the specific MediaInfo version, given the (platform, arch)
-MEDIAINFO_HASHES: dict[tuple[str, str], str] = {
-    ("linux", "x86_64"): "13c4afb2948187cc06f13b1cd7d7a49f8618b8d1e3a440d9e96ef7b486a653d5e2567aae97dc253e3d3f484a7837e4b5a972abab4803223300a79c601c0bcce1",
-    ("linux", "arm64"): "4e5a9826fa987f4bde46a6586894d45f3d5381f25d8886dfef67f5db3a9f4377ecafc12acc6e2d71e43b062b686c2db2523052a1f3dd7505a41091847788d114",
-    # The same file is used for darwin x86_64 and arm64 (suffixed Mac_x86_64+arm64.tar.bz2)
-    ("darwin", "x86_64"): "65b8195f0859369fa0ab1870cbde1535bb57f16bde451b22585d849c870f1ca92972328c11edd15b6f8187445dd58efff7107cfce39d2be7a88e8c434589b4ae",
-    ("darwin", "arm64"): "65b8195f0859369fa0ab1870cbde1535bb57f16bde451b22585d849c870f1ca92972328c11edd15b6f8187445dd58efff7107cfce39d2be7a88e8c434589b4ae",
-    ("win32", "x86_64"): "f831c588e9eaf51201b4cc7995dce66852591764fc5ef05effd3a8a2037ff5d37ec039eef5d1f990f05bd7452c1cad720e95b77a095f9f1a690689e351fc00b8",
-    ("win32", "i386"): "0f0e14c103eac858fe683ec7d51634d62e5e0af658940fd26608249f1048846a92a334438204fe5ecfceb70cb00e5550bfb717a77f10816a2583b5041bb61790",
-}
-# fmt: on
+#: Base URL for downloading MediaInfo CLI
+BASE_URL_CLI: str = "https://mediaarea.net/download/binary/mediainfo"
 
 
-def get_file_blake2b(file_path: os.PathLike | str, chunksize: int = 1 << 20) -> str:
+def get_file_blake2b(file_path: os.PathLike[str] | str, chunksize: int = 1 << 20) -> str:
     """Get the BLAKE2b hash of a file."""
     blake2b = hashlib.blake2b()
     with open(file_path, "rb") as f:
@@ -55,8 +48,20 @@ def get_file_blake2b(file_path: os.PathLike | str, chunksize: int = 1 << 20) -> 
 class Downloader:
     """Downloader for the MediaInfo library files."""
 
+    #: Version of the bundled MediaInfo library
+    version: str
+
+    #: Platform of the bundled MediaInfo library
     platform: Literal["linux", "darwin", "win32"]
+
+    #: Architecture of the bundled MediaInfo library
     arch: Literal["x86_64", "arm64", "i386"]
+
+    #: Download the CLI or library MediaInfo
+    get_cli: bool = False
+
+    #: BLAKE2b hash of the downloaded MediaInfo library
+    checksums: str | None = None
 
     def __post_init__(self) -> None:
         """Check that the combination of platform and arch is allowed."""
@@ -64,58 +69,91 @@ class Downloader:
         if self.platform in ("linux", "darwin"):
             allowed_arch = ["x86_64", "arm64"]
         elif self.platform == "win32":
-            allowed_arch = ["x86_64", "i386"]
+            allowed_arch = ["x86_64", "i386", "arm64"]
         else:
-            raise ValueError(f"platform not recognized: {self.platform}")
+            msg = f"platform not recognized: {self.platform}"
+            raise ValueError(msg)
 
         # Check the platform and arch is a valid combination
         if allowed_arch is not None and self.arch not in allowed_arch:
-            raise ValueError(
+            msg = (
                 f"arch {self.arch} is not allowed for platform {self.platform}; "
                 f"must be one of {allowed_arch}"
             )
+            raise ValueError(msg)
 
-    def get_compressed_file_name(self) -> str:
-        """Get the compressed file name."""
+    @property
+    def win_arch(self) -> str:
+        """Arch for Windows as it appears in MediaInfo downloads."""
+        win_arch: str = self.arch
+        if self.arch == "x86_64":
+            win_arch = "x64"
+        elif self.arch == "arm64":
+            win_arch = "ARM64"
+        return win_arch
+
+    def get_compressed_lib_file_name(self) -> str:
+        """Get the compressed library file name."""
         if self.platform == "linux":
             suffix = f"Lambda_{self.arch}.zip"
         elif self.platform == "darwin":
             suffix = "Mac_x86_64+arm64.tar.bz2"
         elif self.platform == "win32":
-            win_arch = "x64" if self.arch == "x86_64" else self.arch
-            suffix = f"Windows_{win_arch}_WithoutInstaller.zip"
+            suffix = f"Windows_{self.win_arch}_WithoutInstaller.zip"
         else:
-            raise ValueError(f"platform not recognized: {self.platform}")
+            msg = f"platform not recognized: {self.platform}"
+            raise ValueError(msg)
 
-        return f"MediaInfo_DLL_{MEDIAINFO_VERSION}_{suffix}"
+        return f"MediaInfo_DLL_{self.version}_{suffix}"
 
-    def get_url(self) -> str:
+    def get_compressed_cli_file_name(self) -> str:
+        """Get the compressed CLI file name."""
+        if self.platform == "linux":
+            suffix = f"Lambda_{self.arch}.zip"
+        elif self.platform == "darwin":
+            suffix = "Mac.dmg"
+        elif self.platform == "win32":
+            suffix = f"Windows_{self.win_arch}.zip"
+        else:
+            msg = f"platform not recognized: {self.platform}"
+            raise ValueError(msg)
+
+        return f"MediaInfo_CLI_{self.version}_{suffix}"
+
+    def get_compressed_file_name(self) -> str:
+        """Get the compressed file name."""
+        if self.get_cli:
+            return self.get_compressed_cli_file_name()
+        return self.get_compressed_lib_file_name()
+
+    def get_url(self, file_name: str) -> str:
         """Get the URL to download the MediaInfo library."""
-        compressed_file = self.get_compressed_file_name()
-        return f"{BASE_URL}/{MEDIAINFO_VERSION}/{compressed_file}"
+        base_url = BASE_URL_CLI if self.get_cli else BASE_URL_LIB
+        return f"{base_url}/{self.version}/{file_name}"
 
     def compare_hash(self, h: str) -> bool:
         """Compare downloaded hash with expected."""
-        key = (self.platform, self.arch)
-        expected = MEDIAINFO_HASHES.get(key)
         # Check expected hash exists
-        if expected is None:
-            raise ValueError(f"{key}, expected hash not found.")
+        if self.checksums is None:
+            msg = "hash was not provided."
+            raise ValueError(msg)
 
         # Check hashes match
-        if expected != h:
-            raise ValueError(f"hash mismatch for {key}: expected {expected}, got {h}")
+        if self.checksums != h:
+            key = (self.platform, self.arch)
+            msg = f"hash mismatch for {key}: expected {self.checksums}, got {h}"
+            raise ValueError(msg)
 
         return True
 
     def download_upstream(
         self,
         url: str,
-        outpath: os.PathLike,
+        outpath: os.PathLike[str],
         *,
+        check_hash: bool = True,
         timeout: int = 20,
-        verbose: bool = True,
-    ) -> None:
+    ) -> str:
         """Download the compressed file from upstream URL."""
         response = requests.get(url, stream=True, timeout=timeout)
         response.raise_for_status()
@@ -124,26 +162,40 @@ class Downloader:
                 f.write(chunk)
 
         downloaded_hash = get_file_blake2b(outpath)
-        self.compare_hash(downloaded_hash)
+        if check_hash:
+            self.compare_hash(downloaded_hash)
+        return downloaded_hash
 
     def unpack(
         self,
-        file: os.PathLike | str,
-        folder: os.PathLike | str,
+        file: os.PathLike[str] | str,
+        folder: os.PathLike[str] | str,
     ) -> dict[str, str]:
         """Extract compressed files."""
         file = Path(file)
         folder = Path(folder)
-        compressed_file = self.get_compressed_file_name()
 
         if not file.is_file():
-            raise ValueError(f"compressed file not found: {file.name!r}")
+            msg = f"compressed file not found: {file.name!r}"
+            raise ValueError(msg)
         tmp_dir = file.parent
 
         license_file: Path | None = None
         lib_file: Path | None = None
+        libcurl_file: Path | None = None
+
+        # CLI, only for Windows
+        if self.get_cli:
+            if self.platform != "win32":
+                msg = f"uncompressing the CLI source is only done on Windows: {file.name!r}"
+                raise ValueError(msg)
+            with ZipFile(file) as fd:
+                libcurl_file = folder / "libcurl.dll"
+                fd.extract("LIBCURL.DLL", tmp_dir)
+                shutil.move(os.fspath(tmp_dir / "LIBCURL.DLL"), os.fspath(libcurl_file))
+
         # Linux
-        if compressed_file.endswith(".zip") and self.platform == "linux":
+        elif file.name.endswith(".zip") and self.platform == "linux":
             with ZipFile(file) as fd:
                 license_file = folder / "LICENSE"
                 fd.extract("LICENSE", tmp_dir)
@@ -154,7 +206,7 @@ class Downloader:
                 shutil.move(os.fspath(tmp_dir / "lib/libmediainfo.so.0.0.0"), os.fspath(lib_file))
 
         # macOS (darwin)
-        elif compressed_file.endswith(".tar.bz2") and self.platform == "darwin":
+        elif file.name.endswith(".tar.bz2") and self.platform == "darwin":
             with tarfile.open(file) as fd:
                 kwargs: dict[str, Any] = {}
                 # Set for security reasons, see
@@ -177,11 +229,14 @@ class Downloader:
                 )
 
         # Windows (win32)
-        elif compressed_file.endswith(".zip") and self.platform == "win32":
+        elif file.name.endswith(".zip") and self.platform == "win32":
             with ZipFile(file) as fd:
                 license_file = folder / "License.html"
                 fd.extract("Developers/License.html", tmp_dir)
-                shutil.move(os.fspath(tmp_dir / "Developers/License.html"), os.fspath(license_file))
+                shutil.move(
+                    os.fspath(tmp_dir / "Developers/License.html"),
+                    os.fspath(license_file),
+                )
 
                 lib_file = folder / "MediaInfo.dll"
                 fd.extract("MediaInfo.dll", tmp_dir)
@@ -192,28 +247,36 @@ class Downloader:
             files["license"] = os.fspath(license_file.relative_to(folder))
         if lib_file is not None and lib_file.is_file():
             files["lib"] = os.fspath(lib_file.relative_to(folder))
+        if libcurl_file is not None and libcurl_file.is_file():
+            files["libcurl"] = os.fspath(libcurl_file.relative_to(folder))
 
         return files
 
     def download(
         self,
-        folder: os.PathLike | str,
+        folder: os.PathLike[str] | str,
         *,
+        check_hash: bool = True,
         timeout: int = 20,
         verbose: bool = True,
     ) -> dict[str, str]:
         """Download the library and license files."""
         folder = Path(folder)
 
-        url = self.get_url()
         compressed_file = self.get_compressed_file_name()
+        url = self.get_url(compressed_file)
 
         extracted_files = {}
         with TemporaryDirectory() as tmp_dir:
             outpath = Path(tmp_dir) / compressed_file
             if verbose:
                 print(f"Downloading MediaInfo library from {url}")
-            self.download_upstream(url, outpath, timeout=timeout, verbose=verbose)
+            self.download_upstream(
+                url,
+                outpath,
+                check_hash=check_hash,
+                timeout=timeout,
+            )
 
             if verbose:
                 print(f"Extracting {compressed_file}")
@@ -223,22 +286,67 @@ class Downloader:
                 print(f"Extracted files: {extracted_files}")
         return extracted_files
 
+    def get_downloaded_hash(
+        self,
+        *,
+        timeout: int = 20,
+        verbose: bool = True,
+    ) -> str:
+        """Get the hash of the downloaded file."""
+        compressed_file = self.get_compressed_file_name()
+        url = self.get_url(compressed_file)
+
+        with TemporaryDirectory() as tmp_dir:
+            outpath = Path(tmp_dir) / compressed_file
+            if verbose:
+                print(f"Downloading MediaInfo library from {url}")
+            return self.download_upstream(
+                url,
+                outpath,
+                timeout=timeout,
+                check_hash=False,
+            )
+
 
 def download_files(
-    folder: os.PathLike | str,
+    folder: os.PathLike[str] | str,
+    version: str,
     platform: Literal["linux", "darwin", "win32"],
     arch: Literal["x86_64", "arm64", "i386"],
     *,
+    get_cli: bool = False,
+    checksums: str | None = None,
     timeout: int = 20,
     verbose: bool = True,
 ) -> dict[str, str]:
     """Download the library and license files to the output folder."""
-    downloader = Downloader(platform=platform, arch=arch)
+    # Download
+    downloader = Downloader(
+        version=version,
+        platform=platform,
+        arch=arch,
+        get_cli=get_cli,
+        checksums=checksums,
+    )
     return downloader.download(folder, timeout=timeout, verbose=verbose)
 
 
+def get_file_hashes(
+    version: str,
+    platform: Literal["linux", "darwin", "win32"],
+    arch: Literal["x86_64", "arm64", "i386"],
+    *,
+    get_curl: bool = False,
+    timeout: int = 20,
+    verbose: bool = True,
+) -> str:
+    """Download the library and license files to the output folder."""
+    downloader = Downloader(version=version, platform=platform, arch=arch, get_cli=get_curl)
+    return downloader.get_downloaded_hash(timeout=timeout, verbose=verbose)
+
+
 def clean_files(
-    folder: os.PathLike | str,
+    folder: os.PathLike[str] | str,
     *,
     verbose: bool = True,
 ) -> bool:
@@ -249,10 +357,16 @@ def clean_files(
             print(f"folder does not exist: {os.fspath(folder)!r}")
         return False
 
-    glob_patterns = ["License.html", "LICENSE", "MediaInfo.dll", "libmediainfo.*"]
+    glob_patterns = [
+        "License.html",
+        "LICENSE",
+        "MediaInfo.dll",
+        "libmediainfo.*",
+        "libcurl.dll",
+    ]
 
     # list files to delete
-    to_delete: list[os.PathLike] = []
+    to_delete: list[os.PathLike[str]] = []
     for pattern in glob_patterns:
         to_delete.extend(folder.glob(pattern))
 
@@ -265,16 +379,15 @@ def clean_files(
     return True
 
 
-if __name__ == "__main__":
-    import argparse
-    import platform
-
+def make_parser() -> argparse.ArgumentParser:
+    """Make the argument parser."""
     default_folder = Path(__file__).resolve().parent.parent / "src" / "pymediainfo"
 
     parser = argparse.ArgumentParser(
         description="download MediaInfo files from upstream.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
+
     parser.add_argument(
         "-p",
         "--platform",
@@ -294,9 +407,23 @@ if __name__ == "__main__":
         help="use the current platform and architecture",
     )
     parser.add_argument(
+        "-s",
+        "--print-sums",
+        help="download the file from upstream and return the BLAKE2b hash",
+        action="store_true",
+    )
+    parser.add_argument(
         "-q",
         "--quiet",
         help="hide progress messages",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--only-libcurl",
+        help=(
+            "Only for Windows platform, download only the libcurl.dll file. "
+            "If False, download both libmediainfoa and libcurl."
+        ),
         action="store_true",
     )
     parser.add_argument(
@@ -319,6 +446,13 @@ if __name__ == "__main__":
         help="clean the output folder of downloaded files.",
     )
 
+    return parser
+
+
+if __name__ == "__main__":
+    import platform
+
+    parser = make_parser()
     args = parser.parse_args()
 
     if not any((args.auto, args.clean, args.platform and args.arch)):
@@ -331,18 +465,73 @@ if __name__ == "__main__":
         args.platform = platform.system().lower()
         args.arch = platform.machine().lower()
 
+    if args.only_libcurl and args.platform != "win32":
+        # This is only needed on Windows
+        args.only_libcurl = False
+
     # Clean folder
     if args.clean:
         clean_files(args.folder, verbose=not args.quiet)
 
-    # Download files
-    if args.platform is not None and args.arch is not None:
-        extracted_files = download_files(
-            args.folder,
+    # Exit if no platform-arch was provided
+    if args.platform is None or args.arch is None:
+        sys.exit(0)
+
+    # Get version
+    version, info = get_version_and_bundle_info(
+        args.platform,
+        args.arch,
+        get_curl=args.only_libcurl,
+    )
+    # Get checksums
+    checksums = info["blake2b_sums"]
+
+    # Print the checksums and exit
+    if args.print_sums:
+        checksums = get_file_hashes(
+            version,
             args.platform,
             args.arch,
+            get_curl=args.only_libcurl,
+            timeout=args.timeout,
+            verbose=not args.quiet,
+        )
+        print(checksums)
+        sys.exit(0)
+
+    # Download files
+    extracted_files: dict[str, str] = {}
+    extracted_files |= download_files(
+        args.folder,
+        version,
+        args.platform,
+        args.arch,
+        checksums=checksums,
+        get_cli=args.only_libcurl,
+        verbose=not args.quiet,
+        timeout=args.timeout,
+    )
+
+    # Also downloads libcurl on Windows
+    if args.platform == "win32" and not args.only_libcurl:
+        # Get libcurl checksums
+        _, info = get_version_and_bundle_info(args.platform, args.arch, get_curl=True)
+        # Get checksums
+        checksums = info["blake2b_sums"]
+
+        extracted_files |= download_files(
+            args.folder,
+            version,
+            args.platform,
+            args.arch,
+            checksums=checksums,
+            get_cli=True,
             verbose=not args.quiet,
             timeout=args.timeout,
         )
+
+    # Print summary
+    if not args.quiet:
+        print(f"All downloaded files: {extracted_files}")
 
     sys.exit(0)

--- a/scripts/mediainfo_config.py
+++ b/scripts/mediainfo_config.py
@@ -1,0 +1,155 @@
+# ruff: noqa: T201
+"""Download binary library files from <https://mediaarea.net/en/MediaInfo/Download/>."""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+import tomlkit
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from typing import Literal, NotRequired, TypedDict
+
+    class BundledWheelInfo(TypedDict):
+        """Info about a bundled wheel."""
+
+        platform: Literal["linux", "darwin", "win32"]
+        arch: Literal["x86_64", "arm64", "i386"]
+        blake2b_sums: str
+        tag: NotRequired[str]
+        cli_source: NotRequired[bool]
+
+    class MediainfoConfigDict(TypedDict):
+        """Configuration of the bundled wheels."""
+
+        version: str
+        wheel: list[BundledWheelInfo]
+
+
+#: The path of the default pyproject.toml config file."""
+DEFAULT_CONFIG_FILE = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+
+def get_mediainfo_config() -> MediainfoConfigDict:
+    """Read information about the MediaInfo library to bundle from pyproject.toml."""
+    # read toml
+    config = tomlkit.parse(DEFAULT_CONFIG_FILE.read_text(encoding="utf-8"))
+    media_info_config = config["tool"].setdefault("bundled_libmediainfo", {})  # type: ignore[union-attr]
+
+    # check config
+    if "version" not in media_info_config:
+        msg = (
+            "mandatory key 'version' missing from [tool.bundled_libmediainfo] "
+            f"in {DEFAULT_CONFIG_FILE}"
+        )
+        raise ValueError(msg)
+
+    if "wheel" not in media_info_config:
+        msg = (
+            f"mandatory table missing [[tool.bundled_libmediainfo.wheel]] in {DEFAULT_CONFIG_FILE}"
+        )
+        raise ValueError(msg)
+
+    return cast("MediainfoConfigDict", media_info_config)
+
+
+def get_bundle_info(
+    config: list[BundledWheelInfo],
+    platform: str,
+    arch: str,
+    *,
+    get_curl: bool = False,
+) -> BundledWheelInfo:
+    """Get the information about the wheel for the specific platform and arch."""
+    for info in config:
+        if (
+            info["platform"] == platform
+            and info["arch"] == arch
+            and bool(info.get("cli_source", False)) == get_curl
+        ):
+            return info
+
+    # No match
+    key = (platform, arch, f"get_curl={get_curl}")
+    msg = f"No match for {key}"
+    raise KeyError(msg)
+
+
+def get_version() -> str:
+    """Get Mediainfo version from the config file."""
+    mediainfo_config = get_mediainfo_config()
+    return mediainfo_config["version"]
+
+
+def get_version_and_bundle_info(
+    platform: str,
+    arch: str,
+    *,
+    get_curl: bool = False,
+) -> tuple[str, BundledWheelInfo]:
+    """Get Mediainfo version and specific information for the bundled library."""
+    mediainfo_config = get_mediainfo_config()
+    version = mediainfo_config["version"]
+
+    info = get_bundle_info(
+        mediainfo_config["wheel"],
+        platform,
+        arch,
+        get_curl=get_curl,
+    )
+    return version, info
+
+
+@contextmanager
+def modify_config(
+    config_file: str | os.PathLike[str] | None = None,
+    *,
+    verbose: bool = True,
+) -> Iterator[MediainfoConfigDict]:
+    """Modify a the [tool.bundled_libmediainfo] section of a toml file.
+
+    This is a context manager, any change to the yielded dict will be written in
+    the file at the end. If the [tool.bundled_libmediainfo] section does not
+    exist, the changed will be ignored and the toml file will not be modified.
+
+    Example:
+    >>> with modify_config() as media_info_config:
+    ...     media_info_config["version"] = version
+
+    """
+    config_file = Path(config_file or DEFAULT_CONFIG_FILE)
+
+    # Read config
+    config = tomlkit.parse(config_file.read_text(encoding="utf-8"))
+    if "tool" not in config or "bundled_libmediainfo" not in config["tool"]:  # type: ignore[operator]
+        if verbose:
+            print(
+                "the [tool.bundled_libmediainfo] was not found in the config, "
+                f"the file will not be modified: {os.fspath(config_file)!r}"
+            )
+        # yield a minimalist MediainfoConfigDict for compatibility
+        yield {"version": "", "wheel": []}
+        return
+
+    media_info_config = config["tool"]["bundled_libmediainfo"]  # type: ignore[index]
+    yield cast("MediainfoConfigDict", media_info_config)
+
+    # Maybe we could output a diff of the changes
+    if verbose:
+        print(f"Will modify the content of {os.fspath(config_file)!r}")
+
+    # Write modified content
+    with open(config_file, "w") as f:
+        f.write(tomlkit.dumps(config))
+
+
+def update_config_version(version: str, *, verbose: bool = True) -> None:
+    """Update MediaInfo bundled version in the config file."""
+    # Read config and modify
+    with modify_config(verbose=verbose) as media_info_config:
+        # Update version
+        media_info_config["version"] = version

--- a/scripts/mediainfo_config.py
+++ b/scripts/mediainfo_config.py
@@ -12,16 +12,15 @@ import tomlkit
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-    from typing import Literal, NotRequired, TypedDict
+    from typing import Literal, TypedDict
 
     class BundledWheelInfo(TypedDict):
         """Info about a bundled wheel."""
 
+        tag: str
         platform: Literal["linux", "darwin", "win32"]
         arch: Literal["x86_64", "arm64", "i386"]
         blake2b_sums: str
-        tag: NotRequired[str]
-        cli_source: NotRequired[bool]
 
     class MediainfoConfigDict(TypedDict):
         """Configuration of the bundled wheels."""
@@ -57,24 +56,14 @@ def get_mediainfo_config() -> MediainfoConfigDict:
     return cast("MediainfoConfigDict", media_info_config)
 
 
-def get_bundle_info(
-    config: list[BundledWheelInfo],
-    platform: str,
-    arch: str,
-    *,
-    get_curl: bool = False,
-) -> BundledWheelInfo:
+def get_bundle_info(config: list[BundledWheelInfo], platform: str, arch: str) -> BundledWheelInfo:
     """Get the information about the wheel for the specific platform and arch."""
     for info in config:
-        if (
-            info["platform"] == platform
-            and info["arch"] == arch
-            and bool(info.get("cli_source", False)) == get_curl
-        ):
+        if info["platform"] == platform and info["arch"] == arch:
             return info
 
     # No match
-    key = (platform, arch, f"get_curl={get_curl}")
+    key = (platform, arch)
     msg = f"No match for {key}"
     raise KeyError(msg)
 
@@ -88,8 +77,6 @@ def get_version() -> str:
 def get_version_and_bundle_info(
     platform: str,
     arch: str,
-    *,
-    get_curl: bool = False,
 ) -> tuple[str, BundledWheelInfo]:
     """Get Mediainfo version and specific information for the bundled library."""
     mediainfo_config = get_mediainfo_config()
@@ -99,7 +86,6 @@ def get_version_and_bundle_info(
         mediainfo_config["wheel"],
         platform,
         arch,
-        get_curl=get_curl,
     )
     return version, info
 

--- a/scripts/tag_pure_wheels.py
+++ b/scripts/tag_pure_wheels.py
@@ -14,7 +14,7 @@ from wheel.cli.tags import tags  # type: ignore[import-untyped]
 script_folder = Path(__file__).resolve().parent
 sys.path.append(str(script_folder))
 
-from mediainfo_config import get_version_and_bundle_info  # noqa: E402
+from mediainfo_config import get_current_platform_and_arch, get_version_and_bundle_info  # noqa: E402
 
 if TYPE_CHECKING:
     import os
@@ -82,8 +82,7 @@ if __name__ == "__main__":
         parser.error("either -A/--auto, or -a/--arch with -p/--platform must be used")
 
     if args.auto:
-        args.platform = platform.system().lower()
-        args.arch = platform.machine().lower()
+        args.platform, args.arch = get_current_platform_and_arch()
 
     # Get platform_tag from pyproject.toml
     if not args.platform_tag:

--- a/scripts/tag_pure_wheels.py
+++ b/scripts/tag_pure_wheels.py
@@ -3,16 +3,79 @@
 # ruff: noqa: T201
 """Tags all pure Python wheels from the 'dist' folder."""
 
-import argparse
-import pathlib
+from __future__ import annotations
 
-from wheel.cli.tags import tags
+import argparse
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from wheel.cli.tags import tags  # type: ignore[import-untyped]
+
+script_folder = Path(__file__).resolve().parent
+sys.path.append(str(script_folder))
+
+from mediainfo_config import get_version_and_bundle_info  # noqa: E402
+
+if TYPE_CHECKING:
+    import os
+
+#: Default 'dist' directory
+DEFAULT_DIST_DIR = Path(__file__).resolve().parent.parent / "dist"
+
+
+def tag_wheel(
+    platform_tag: str,
+    folder: str | os.PathLike[str] | None = None,
+    *,
+    verbose: bool = True,
+) -> list[str]:
+    """Tag the wheels in folder with new platform tags."""
+    dist_dir = Path(folder or DEFAULT_DIST_DIR)
+
+    new_wheels = []
+    for wheel_path in dist_dir.glob("*-py3-none-any.whl"):
+        new_wheel = tags(wheel_path, platform_tags=platform_tag, remove=True)
+        if verbose:
+            print(f"Tagged {wheel_path.name} -> {new_wheel}")
+        new_wheels.append(new_wheel)
+
+    return new_wheels
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("platform_tag", help="the tag to add")
+    parser.add_argument(
+        "-p",
+        "--platform",
+        choices=["linux", "darwin", "win32"],
+        help="platform of the library",
+    )
+    parser.add_argument(
+        "-a",
+        "--arch",
+        choices=["x86_64", "arm64", "i386"],
+        help="architecture of the library",
+    )
+    parser.add_argument(
+        "--platform_tag",
+        help="the tag to add",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        help="hide progress messages",
+        action="store_true",
+    )
     args = parser.parse_args()
 
-    for wheel_path in pathlib.Path("dist").glob("*-py3-none-any.whl"):
-        new_wheel = tags(wheel_path, platform_tags=args.platform_tag, remove=True)
-        print(f"Tagged {wheel_path.name} -> {new_wheel}")
+    # Get platform_tag from pyproject.toml
+    if not args.platform_tag:
+        version, info = get_version_and_bundle_info(args.platform, args.arch)
+        if "tag" not in info:
+            msg = f"platform tag was not defined in the configuration file: {info}"
+            raise ValueError(msg)
+        args.platform_tag = info["tag"]
+
+    # Tag the wheels with a new platform tag
+    tag_wheel(args.platform_tag, verbose=not args.quiet)

--- a/scripts/update_checksums.py
+++ b/scripts/update_checksums.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+# ruff: noqa: T201, E402
+"""Update the bundled MediaInfo version and checksums in the pyproject.toml file."""
+
+import argparse
+import sys
+from pathlib import Path
+
+import requests
+
+script_folder = Path(__file__).resolve().parent
+sys.path.append(str(script_folder))
+
+from download_library import get_file_hashes
+from mediainfo_config import get_version, modify_config, update_config_version
+
+#: API to fetch the latest release of MediaInfo
+LATEST_RELEASE_URL = "https://api.github.com/repos/MediaArea/MediaInfo/releases/latest"
+
+
+def get_last_version(*, timeout: int = 20) -> str:
+    """Fetch the value of the latest MediaInfo version from the Github repo."""
+    # Fetch the latest release using Github API
+    response = requests.get(LATEST_RELEASE_URL, timeout=timeout)
+    response.raise_for_status()
+    json = response.json()
+
+    if "name" not in json:
+        msg = f"cannot read the version of the latest MediaInfo release:\n{json}"
+        raise ValueError(msg)
+
+    return str(json["name"])
+
+
+def update_version(*, timeout: int = 20, verbose: bool = True) -> str:
+    """Update the version of the bundled mediainfo library."""
+    # Get latest version
+    latest_version = get_last_version(timeout=timeout)
+
+    # Get version from config file
+    version = get_version()
+
+    # If already latest version, early return
+    if version == latest_version:
+        return latest_version
+
+    # Update version in pyproject.toml
+    update_config_version(latest_version, verbose=verbose)
+
+    return latest_version
+
+
+def update_hashes(*, update_version: bool = False, timeout: int = 20, verbose: bool = True) -> None:
+    """Update the hashes of the downloaded mediainfo library."""
+    with modify_config(verbose=verbose) as media_info_config:
+        version = media_info_config["version"]
+
+        if update_version:
+            # Get latest version
+            new_version = get_last_version(timeout=timeout)
+            if new_version != version:
+                if verbose:
+                    print(f"Update MediaInfo {version} -> {new_version}")
+                version = new_version
+            media_info_config["version"] = version
+
+        for info in media_info_config["wheel"]:
+            # Update checksums
+            try:
+                checksums = get_file_hashes(
+                    version,
+                    info["platform"],
+                    info["arch"],
+                    get_curl=bool(info.get("cli_source", False)),
+                )
+            except Exception as e:  # noqa: BLE001
+                if verbose:
+                    print(e)
+            else:
+                info["blake2b_sums"] = checksums
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-V",
+        "--only-version",
+        help="only update the version",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-C",
+        "--only-checksums",
+        help="only update the checksums",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        help="hide progress messages",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        help="URL request timeout in seconds",
+        default=20,
+    )
+
+    args = parser.parse_args()
+
+    if args.only_version:
+        update_version(timeout=args.timeout, verbose=not args.quiet)
+    else:
+        update_hashes(
+            update_version=not args.only_checksums,
+            timeout=args.timeout,
+            verbose=not args.quiet,
+        )

--- a/scripts/update_checksums.py
+++ b/scripts/update_checksums.py
@@ -72,7 +72,6 @@ def update_hashes(*, update_version: bool = False, timeout: int = 20, verbose: b
                     version,
                     info["platform"],
                     info["arch"],
-                    get_curl=bool(info.get("cli_source", False)),
                 )
             except Exception as e:  # noqa: BLE001
                 if verbose:

--- a/tests/test_pymediainfo.py
+++ b/tests/test_pymediainfo.py
@@ -163,8 +163,8 @@ class MediaInfoUnicodeFileNameTest(unittest.TestCase):
 
 
 @pytest.mark.skipif(
-    sys.version_info < (3, 7),
-    reason="SimpleHTTPRequestHandler's 'directory' argument was added in Python 3.7",
+    sys.platform.startswith("win"),
+    reason="The bundled libmediainfo library is not compiled with libcurl on Windows",
 )
 class MediaInfoURLTest(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
Follow-up to https://github.com/sbraz/pymediainfo/pull/141#issuecomment-2646822640

This PR adds a script to update the version of the bundled libmediainfo library and to update the checksums of the files to download from MediaInfo.

Instead of hard-coding the mediainfo version and hashes in the `download_library.py` script, this information is put in `pyproject.toml`. Then the new `update_checksums.py` scripts is used to update the values in the `pyproject.toml` config file.

A typical workflow to regenerate bundled wheels with the latest MediaInfo version, for all the platforms and architectures:

```shell
pdm run update_checksums
pdm run build_all
```