### PR TITLE
Add pre commit with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-toml
+      - id: check-yaml
+      - id: end-of-file-fixer
+
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.29.5
+    hooks:
+      - id: typos
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.6
+    hooks:
+      - id: ruff
+        args: [--fix, --unsafe-fixes]
+      - id: ruff-format
+
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.23
+    hooks:
+      - id: validate-pyproject
+        name: validate-pyproject

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
   TWINE_PASSWORD:
     secure: Jp2QpmAii1mmAXmotdXmPx5q679oMcRolziuu9m2pawkvOnRJtWMsI4uWiTiSbiw+HMbyyWwVpy+FiaPsHZxtM863PNNJidW1WDam4kn8EM+rznjgZfO9NSCcwZJU5jcTYCwuXo3+FnVNK5rvQ8QJ+Zu6WzH1Ysb+uJSz8e6xt7d7hoZbb9VH5bJC7tYrw+bH+TfA9juVpIYfCavozLLTDLqTcvPfJ+LXMPbiZO+oOztNsLRsviH2QAPXaLspXvCr6qUVH3A84KCdfSXCOZG0g/eYUZ6ilMLESe7DrYZrRc=
   matrix:
-    - TOXENV: docs,black,flake8,isort,mypy,pylint
+    - TOXENV: pre-commit,docs,mypy
       APPVEYOR_BUILD_WORKER_IMAGE: *linux_image
       # The BUILD_TYPE variable allows us to separate normal Linux builds from
       # the QA one

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # pymediainfo documentation build configuration file, created by
 # sphinx-quickstart on Tue Feb  9 10:51:37 2016.
@@ -18,37 +16,37 @@ from importlib.metadata import version as get_version
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+# sys.path.insert(0, os.path.abspath('.'))
 
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+# needs_sphinx = '1.0'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'myst_parser',
-    'sphinx.ext.autodoc',
+    "myst_parser",
+    "sphinx.ext.autodoc",
 ]
 
 # Type hints aren't very readable in the doc at the moment
 autodoc_typehints = "none"
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The encoding of source files.
-#source_encoding = 'utf-8-sig'
+# source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = 'pymediainfo'
-copyright = 'Patrick Altman, Louis Sautier'
-author = 'Patrick Altman, Louis Sautier'
+project = "pymediainfo"
+copyright = "Patrick Altman, Louis Sautier"
+author = "Patrick Altman, Louis Sautier"
 
 # fallback_root must be specified for this to work with PyPI tarballs
 version = get_version("pymediainfo")
@@ -65,37 +63,37 @@ language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+# today = ''
 # Else, today_fmt is used as the format for a strftime call.
-#today_fmt = '%B %d, %Y'
+# today_fmt = '%B %d, %Y'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ["_build"]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-#default_role = None
+# default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
+# add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
-#add_module_names = True
+# add_module_names = True
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.
-#show_authors = False
+# show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # A list of ignored prefixes for module index sorting.
-#modindex_common_prefix = []
+# modindex_common_prefix = []
 
 # If true, keep warnings as "system message" paragraphs in the built documents.
-#keep_warnings = False
+# keep_warnings = False
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
@@ -105,7 +103,7 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'alabaster'
+html_theme = "alabaster"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -119,23 +117,23 @@ html_theme_options = {
 }
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+# html_theme_path = []
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+# html_title = None
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+# html_short_title = None
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-#html_logo = None
+# html_logo = None
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-#html_favicon = None
+# html_favicon = None
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -145,122 +143,121 @@ html_static_path = []
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-#html_extra_path = []
+# html_extra_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
+# html_last_updated_fmt = '%b %d, %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-#html_use_smartypants = True
+# html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
+# html_sidebars = {}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
-#html_additional_pages = {}
+# html_additional_pages = {}
 
 # If false, no module index is generated.
-#html_domain_indices = True
+# html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+# html_use_index = True
 
 # If true, the index is split into individual pages for each letter.
-#html_split_index = False
+# html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+# html_show_sourcelink = True
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-#html_show_sphinx = True
+# html_show_sphinx = True
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
-#html_show_copyright = True
+# html_show_copyright = True
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-#html_use_opensearch = ''
+# html_use_opensearch = ''
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = None
+# html_file_suffix = None
 
 # Language to be used for generating the HTML full-text search index.
 # Sphinx supports the following languages:
 #   'da', 'de', 'en', 'es', 'fi', 'fr', 'h', 'it', 'ja'
 #   'nl', 'no', 'pt', 'ro', 'r', 'sv', 'tr'
-#html_search_language = 'en'
+# html_search_language = 'en'
 
 # A dictionary with options for the search language support, empty by default.
 # Now only 'ja' uses this config value
-#html_search_options = {'type': 'default'}
+# html_search_options = {'type': 'default'}
 
 # The name of a javascript file (relative to the configuration directory) that
 # implements a search results scorer. If empty, the default will be used.
-#html_search_scorer = 'scorer.js'
+# html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'pymediainfodoc'
+htmlhelp_basename = "pymediainfodoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
-
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
-
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
-
-# Latex figure (float) alignment
-#'figure_align': 'htbp',
+    # The paper size ('letterpaper' or 'a4paper').
+    #'papersize': 'letterpaper',
+    # The font size ('10pt', '11pt' or '12pt').
+    #'pointsize': '10pt',
+    # Additional stuff for the LaTeX preamble.
+    #'preamble': '',
+    # Latex figure (float) alignment
+    #'figure_align': 'htbp',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'pymediainfo.tex', 'pymediainfo Documentation',
-     'Patrick Altman, Louis Sautier', 'manual'),
+    (
+        master_doc,
+        "pymediainfo.tex",
+        "pymediainfo Documentation",
+        "Patrick Altman, Louis Sautier",
+        "manual",
+    ),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
-#latex_logo = None
+# latex_logo = None
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-#latex_use_parts = False
+# latex_use_parts = False
 
 # If true, show page references after internal links.
-#latex_show_pagerefs = False
+# latex_show_pagerefs = False
 
 # If true, show URL addresses after external links.
-#latex_show_urls = False
+# latex_show_urls = False
 
 # Documents to append as an appendix to all manuals.
-#latex_appendices = []
+# latex_appendices = []
 
 # If false, no module index is generated.
-#latex_domain_indices = True
+# latex_domain_indices = True
 
 
 # -- Options for manual page output ---------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'pymediainfo', 'pymediainfo Documentation',
-     [author], 1)
-]
+man_pages = [(master_doc, "pymediainfo", "pymediainfo Documentation", [author], 1)]
 
 # If true, show URL addresses after external links.
-#man_show_urls = False
+# man_show_urls = False
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -269,22 +266,28 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'pymediainfo', 'pymediainfo Documentation',
-     author, 'pymediainfo', 'One line description of project.',
-     'Miscellaneous'),
+    (
+        master_doc,
+        "pymediainfo",
+        "pymediainfo Documentation",
+        author,
+        "pymediainfo",
+        "One line description of project.",
+        "Miscellaneous",
+    ),
 ]
 
 # Documents to append as an appendix to all manuals.
-#texinfo_appendices = []
+# texinfo_appendices = []
 
 # If false, no module index is generated.
-#texinfo_domain_indices = True
+# texinfo_domain_indices = True
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
-#texinfo_show_urls = 'footnote'
+# texinfo_show_urls = 'footnote'
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
-#texinfo_no_detailmenu = False
+# texinfo_no_detailmenu = False
 
 # See https://github.com/executablebooks/MyST-Parser/discussions/898
 suppress_warnings = ["myst.header"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,14 +13,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import os
-
-import setuptools_scm
-
-try:
-    from importlib import metadata
-except ImportError:
-    import importlib_metadata as metadata  # type: ignore
+from importlib.metadata import version as get_version
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -58,7 +51,7 @@ copyright = 'Patrick Altman, Louis Sautier'
 author = 'Patrick Altman, Louis Sautier'
 
 # fallback_root must be specified for this to work with PyPI tarballs
-version = setuptools_scm.get_version(root="..", fallback_root="..", relative_to=__file__)
+version = get_version("pymediainfo")
 
 # The full version, including alpha/beta/rc tags.
 release = version

--- a/docs/pymediainfo.rst
+++ b/docs/pymediainfo.rst
@@ -10,15 +10,18 @@ API reference
 Library autodetection
 =====================
 
-Whenever a method is called with `library_file=None` (the default), the following logic is used.
+Whenever a method is called with `library_file=None` (the default), the
+following logic is used.
 
 Filename Determination
 -----------------------
 
-First, the library filename is automatically determined based on the operating system:
+First, the library filename is automatically determined based on the operating
+system:
 
 - On **Linux**, `libmediainfo.so.0` is used.
-- On **macOS**, the first available file among `libmediainfo.0.dylib` and `libmediainfo.dylib` is used, in that order.
+- On **macOS**, the first available file among `libmediainfo.0.dylib` and
+    `libmediainfo.dylib` is used, in that order.
 - On **Windows**, `MediaInfo.dll` is used.
 
 Paths Searched
@@ -26,9 +29,10 @@ Paths Searched
 
 Next, the code checks if a matching library file exists in the same directory
 as pymediainfo's ``__init__.py`` and attempts to load it.
-If pymediainfo was installed from a wheel, the bundled library is placed in this location.
+If pymediainfo was installed from a wheel, the bundled library is placed in
+this location.
 
-Last, if no matching file could be loaded from the previous location, the code attempts to
-load the previously determined filename(s) from standard system paths, using
-:class:`ctypes.CDLL` for Linux and macOS, or :class:`ctypes.WinDLL` for
-Windows.
+Last, if no matching file could be loaded from the previous location, the code
+attempts to load the previously determined filename(s) from standard system
+paths, using :class:`ctypes.CDLL` for Linux and macOS, or
+:class:`ctypes.WinDLL` for Windows.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
 alabaster
 myst-parser
-setuptools_scm
 sphinx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 requires-python = ">=3.9"
-dependencies = [
-]
+dependencies = []
 
 [project.optional-dependencies]
 tests = [
@@ -165,5 +164,108 @@ module = ["pymediainfo.*"]
 strict = true
 
 
+# https://docs.pytest.org/en/latest/reference/customize.html
 [tool.pytest.ini_options]
 addopts = "-vv -r a"
+
+
+# https://coverage.readthedocs.io/en/stable/
+[tool.coverage.run]
+source_pkgs = ["pymediainfo", "tests"]
+branch = true
+parallel = true
+omit = [
+  "src/pymediainfo/_version.py",
+]
+
+[tool.coverage.paths]
+pymediainfo = ["src/pymediainfo", "*/pymediainfo/src/pymediainfo"]
+tests = ["tests", "*/pymediainfo/tests"]
+
+[tool.coverage.report]
+exclude_also = [
+  "# pragma: no.cover",
+  "# pragma: no.branch",
+  "if __name__ == .__main__.:",
+  "if TYPE_CHECKING:",
+]
+
+
+# https://docs.astral.sh/ruff/
+[tool.ruff]
+line-length = 100
+src = ["src", "tests", "scripts", "docs"]
+exclude = [
+    "tests/data/*",
+    "_version.py",
+]
+
+[tool.ruff.lint]
+select = ["ALL"]
+ignore = [
+    "ISC001",  # conflict with `ruff format`
+    "D203",    # pydocstyle
+    "D105",
+    "D107",
+    "N802",    # pep8-naming
+    "N803",
+    "N806",
+    "ANN101",
+    "ANN102",
+    "ANN401",  # flake8-annotations
+    "ERA001",  # eradicate
+    "G004",    # flake8-logging-format
+    "TD",      # flake8-todos
+    "COM812",  # flake8-commas
+    "PTH123",  # flake8-use-pathlib
+    "SIM103",  # flake8-simplify
+    "PLR0913", # pylint
+    "PLR2004",
+    "PLR0912", # refactor
+    "PLR0915",
+    "PERF203", # Perflint
+    "PD901",   # pandas-vet
+    ### to be removed
+    "C901",    # mccabe
+]
+unfixable = [
+    "T201",
+    "T203",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["E402", "D104"]
+"**/tests/*" = [
+    "D",
+    "S",
+    "RUF012",
+    "N999",
+    "E402",
+    "INP001",
+    "PTH",
+    "T201",
+    "ANN",
+    "SLF",
+    "FBT",
+]
+"**/scripts/*" = ["INP001"]
+"**/docs/*" = [
+    "A001",
+    "D100",
+    "INP001",
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "pep257"
+
+# https://docs.astral.sh/ruff/formatter/
+[tool.ruff.format]
+docstring-code-format = true
+
+
+# https://github.com/crate-ci/typos/blob/master/docs/reference.md
+[tool.typos.default]
+extend-ignore-re = [
+    "(?Rm)^.*#\\s*spellchecker:\\s*disable-line$",
+    "#\\s*spellchecker:off\\s*\\n.*\\n\\s*#\\s*spellchecker:on"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,16 +39,13 @@ tests = [
 docs = [
     "alabaster",
     "myst-parser",
-    "setuptools_scm",
     "sphinx",
 ]
 dev = [
+    "pre-commit",
     "ipython",
+    "ruff",
     "mypy>=1.0",
-    "black",
-    "isort",
-    "flake8",
-    "pylint",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,10 @@ dev = [
     "ipython",
     "ruff",
     "mypy>=1.0",
+    "tomlkit",
+    "requests",
+    "types-requests",
+    "wheel>=0.44",
 ]
 
 [project.urls]

--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
-# ruff: noqa: T201
+# ruff: noqa: T201, T203
 """A demo that shows how to call pymediainfo."""
 
-import argparse
+from __future__ import annotations
+
 from pprint import pprint
 
 from pymediainfo import MediaInfo
 
 
 def process(media_file: str) -> None:
+    """Process the file."""
     print(f"Processing {media_file}")
     media_info = MediaInfo.parse(media_file)
     for track in media_info.tracks:
@@ -18,20 +20,24 @@ def process(media_file: str) -> None:
             pprint(track.to_data())
         elif track.track_type == "Video":
             print(
-                f"Video track {track.track_id} has a resolution of {track.width}×{track.height}",
+                f"Video track {track.track_id} has a resolution of {track.width}×{track.height}",  # noqa: RUF001
                 f"and a bit rate of {track.bit_rate} bits/s",
             )
         elif track.track_type == "Audio":
             if track.duration is not None:
                 print(
-                    f"Audio track {track.track_id} has a duration of {track.duration/1000} seconds"
+                    f"Audio track {track.track_id} has a duration of "
+                    f"{track.duration / 1000} seconds"
                 )
 
 
 if __name__ == "__main__":
+    import argparse
+
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("media_file", nargs="+", help="media files to parse")
     args = parser.parse_args()
+
     for index, media_file in enumerate(args.media_file):
         if index != 0:
             print()

--- a/src/pymediainfo/__init__.py
+++ b/src/pymediainfo/__init__.py
@@ -1,6 +1,4 @@
-"""
-This module is a wrapper for the MediaInfo library.
-"""
+"""This module is a wrapper for the MediaInfo library."""
 
 from __future__ import annotations
 
@@ -12,12 +10,13 @@ import re
 import sys
 import warnings
 import xml.etree.ElementTree as ET
-from importlib import metadata
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as get_version
 from typing import Any, overload
 
 try:
-    __version__ = metadata.version("pymediainfo")
-except metadata.PackageNotFoundError:
+    __version__ = get_version("pymediainfo")
+except PackageNotFoundError:
     __version__ = ""
 
 

--- a/tests/data/invalid.xml
+++ b/tests/data/invalid.xml
@@ -213,4 +213,3 @@
 
 </File>
 </Mediainfo>
-

--- a/tests/test_pymediainfo.py
+++ b/tests/test_pymediainfo.py
@@ -198,32 +198,6 @@ class MediaInfoPathlibTest(unittest.TestCase):
         self.assertRaises(FileNotFoundError, MediaInfo.parse, path)
 
 
-class MediaInfoFilenameTypesTest(unittest.TestCase):
-    def test_normalize_filename_str(self) -> None:
-        path = os.path.join(data_dir, "test.txt")
-        filename = MediaInfo._normalize_filename(path)
-        self.assertEqual(filename, path)
-
-    def test_normalize_filename_pathlib(self) -> None:
-        path = pathlib.Path(data_dir, "test.txt")
-        filename = MediaInfo._normalize_filename(path)
-        self.assertEqual(filename, os.path.join(data_dir, "test.txt"))
-
-    def test_normalize_filename_pathlike(self) -> None:
-        class PathLikeObject(os.PathLike[str]):
-            # pylint: disable=too-few-public-methods
-            def __fspath__(self) -> str:
-                return os.path.join(data_dir, "test.txt")
-
-        path = PathLikeObject()
-        filename = MediaInfo._normalize_filename(path)
-        self.assertEqual(filename, os.path.join(data_dir, "test.txt"))
-
-    def test_normalize_filename_url(self) -> None:
-        filename = MediaInfo._normalize_filename("https://localhost")
-        self.assertEqual(filename, "https://localhost")
-
-
 class MediaInfoTestParseNonExistentFile(unittest.TestCase):
     def test_parse_non_existent_path(self) -> None:
         path = os.path.join(data_dir, "this file does not exist")

--- a/tests/test_pymediainfo.py
+++ b/tests/test_pymediainfo.py
@@ -7,18 +7,19 @@ import json
 import os
 import pathlib
 import pickle
+import re
 import sys
 import tempfile
 import threading
 import unittest
-import xml
+from xml.etree import ElementTree as ET
 
 import pytest
 
 from pymediainfo import MediaInfo
 
 data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
-test_media_files = [
+test_media_files: list[str] = [
     "sample.mkv",
     "sample.mp4",
     "sample_with_cover.mp3",
@@ -37,26 +38,26 @@ def _get_library_version() -> tuple[str, tuple[int, ...]]:
 
 class MediaInfoTest(unittest.TestCase):
     def setUp(self) -> None:
-        with open(os.path.join(data_dir, "sample.xml"), "r", encoding="utf-8") as f:
+        with open(os.path.join(data_dir, "sample.xml"), encoding="utf-8") as f:
             self.xml_data = f.read()
         self.media_info = MediaInfo(self.xml_data)
 
     def test_populate_tracks(self) -> None:
-        self.assertEqual(4, len(self.media_info.tracks))
+        assert len(self.media_info.tracks) == 4
 
     def test_valid_video_track(self) -> None:
         for track in self.media_info.tracks:
             if track.track_type == "Video":
-                self.assertEqual("DV", track.codec)
-                self.assertEqual("Interlaced", track.scan_type)
+                assert track.codec == "DV"
+                assert track.scan_type == "Interlaced"
                 break
 
     def test_track_integer_attributes(self) -> None:
         for track in self.media_info.tracks:
             if track.track_type == "Audio":
-                self.assertTrue(isinstance(track.duration, int))
-                self.assertTrue(isinstance(track.bit_rate, int))
-                self.assertTrue(isinstance(track.sampling_rate, int))
+                assert isinstance(track.duration, int)
+                assert isinstance(track.bit_rate, int)
+                assert isinstance(track.sampling_rate, int)
                 break
 
     def test_track_other_attributes(self) -> None:
@@ -64,32 +65,31 @@ class MediaInfoTest(unittest.TestCase):
             track for track in self.media_info.tracks if track.track_type == "General"
         ]
         general_track = general_tracks[0]
-        self.assertEqual(5, len(general_track.other_file_size))
-        self.assertEqual(
-            ["1mn 1s", "1mn 1s 394ms", "1mn 1s", "00:01:01.394"], general_track.other_duration
-        )
+        assert len(general_track.other_file_size) == 5
+        assert general_track.other_duration == ["1mn 1s", "1mn 1s 394ms", "1mn 1s", "00:01:01.394"]
 
     def test_track_existing_other_attributes(self) -> None:
         with open(os.path.join(data_dir, "issue100.xml"), encoding="utf-8") as f:
             media_info = MediaInfo(f.read())
         general_tracks = [track for track in media_info.tracks if track.track_type == "General"]
         general_track = general_tracks[0]
-        self.assertEqual(general_track.other_format_list, "RTP / RTP")
+        assert general_track.other_format_list == "RTP / RTP"
 
     def test_load_mediainfo_from_string(self) -> None:
-        self.assertEqual(4, len(self.media_info.tracks))
+        assert len(self.media_info.tracks) == 4
 
     def test_getting_attribute_that_doesnot_exist(self) -> None:
-        self.assertTrue(self.media_info.tracks[0].does_not_exist is None)
+        assert self.media_info.tracks[0].does_not_exist is None
 
 
 class MediaInfoInvalidXMLTest(unittest.TestCase):
     def setUp(self) -> None:
-        with open(os.path.join(data_dir, "invalid.xml"), "r", encoding="utf-8") as f:
+        with open(os.path.join(data_dir, "invalid.xml"), encoding="utf-8") as f:
             self.xml_data = f.read()
 
     def test_parse_invalid_xml(self) -> None:
-        self.assertRaises(xml.etree.ElementTree.ParseError, MediaInfo, self.xml_data)
+        with pytest.raises(ET.ParseError):
+            MediaInfo(self.xml_data)
 
 
 class MediaInfoLibraryTest(unittest.TestCase):
@@ -98,31 +98,32 @@ class MediaInfoLibraryTest(unittest.TestCase):
         self.non_full_mi = MediaInfo.parse(os.path.join(data_dir, "sample.mp4"), full=False)
 
     def test_can_parse_true(self) -> None:
-        self.assertTrue(MediaInfo.can_parse())
+        assert MediaInfo.can_parse()
 
     def test_track_count(self) -> None:
-        self.assertEqual(len(self.media_info.tracks), 3)
+        assert len(self.media_info.tracks) == 3
 
     def test_track_types(self) -> None:
-        self.assertEqual(self.media_info.tracks[1].track_type, "Video")
-        self.assertEqual(self.media_info.tracks[2].track_type, "Audio")
+        assert self.media_info.tracks[1].track_type == "Video"
+        assert self.media_info.tracks[2].track_type == "Audio"
 
     def test_track_details(self) -> None:
-        self.assertEqual(self.media_info.tracks[1].format, "AVC")
-        self.assertEqual(self.media_info.tracks[2].format, "AAC")
-        self.assertEqual(self.media_info.tracks[1].duration, 958)
-        self.assertEqual(self.media_info.tracks[2].duration, 980)
+        assert self.media_info.tracks[1].format == "AVC"
+        assert self.media_info.tracks[2].format == "AAC"
+        assert self.media_info.tracks[1].duration == 958
+        assert self.media_info.tracks[2].duration == 980
 
     def test_full_option(self) -> None:
-        self.assertEqual(self.media_info.tracks[0].footersize, "59")
-        self.assertEqual(self.non_full_mi.tracks[0].footersize, None)
+        assert self.media_info.tracks[0].footersize == "59"
+        assert self.non_full_mi.tracks[0].footersize is None
 
     def test_raises_on_nonexistent_library(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             nonexistent_library = os.path.join(tmp_dir, "nonexistent-libmediainfo.so")
-            with pytest.raises(OSError) as exc:
+            with pytest.raises(OSError) as exc:  # noqa: PT011
                 MediaInfo.parse(
-                    os.path.join(data_dir, "sample.mp4"), library_file=nonexistent_library
+                    os.path.join(data_dir, "sample.mp4"),
+                    library_file=nonexistent_library,
                 )
             assert rf"Failed to load library from {nonexistent_library}" in str(exc.value)
 
@@ -133,12 +134,14 @@ class MediaInfoFileLikeTest(unittest.TestCase):
             MediaInfo.parse(f)
 
     def test_raises_on_text_mode_even_with_text(self) -> None:
-        with open(os.path.join(data_dir, "sample.xml"), encoding="utf-8") as f:
-            self.assertRaises(ValueError, MediaInfo.parse, f)
+        path = os.path.join(data_dir, "sample.xml")
+        with open(path, encoding="utf-8") as f, pytest.raises(ValueError):  # noqa: PT011
+            MediaInfo.parse(f)
 
     def test_raises_on_text_mode(self) -> None:
-        with open(os.path.join(data_dir, "sample.mkv"), encoding="utf-8") as f:
-            self.assertRaises(ValueError, MediaInfo.parse, f)
+        path = os.path.join(data_dir, "sample.mkv")
+        with open(path, encoding="utf-8") as f, pytest.raises(ValueError):  # noqa: PT011
+            MediaInfo.parse(f)
 
 
 class MediaInfoUnicodeXMLTest(unittest.TestCase):
@@ -146,12 +149,12 @@ class MediaInfoUnicodeXMLTest(unittest.TestCase):
         self.media_info = MediaInfo.parse(os.path.join(data_dir, "sample.mkv"))
 
     def test_parse_file_with_unicode_tags(self) -> None:
-        self.assertEqual(
-            self.media_info.tracks[0].title,
+        expected = (
             "Dès Noël où un zéphyr haï me vêt de glaçons "
-            "würmiens je dîne d’exquis rôtis de bœuf au kir à "
-            "l’aÿ d’âge mûr & cætera !",
+            "würmiens je dîne d’exquis rôtis de bœuf au kir à "  # noqa: RUF001
+            "l’aÿ d’âge mûr & cætera !"  # noqa: RUF001
         )
+        assert self.media_info.tracks[0].title == expected
 
 
 class MediaInfoUnicodeFileNameTest(unittest.TestCase):
@@ -159,7 +162,7 @@ class MediaInfoUnicodeFileNameTest(unittest.TestCase):
         self.media_info = MediaInfo.parse(os.path.join(data_dir, "accentué.txt"))
 
     def test_parse_unicode_file(self) -> None:
-        self.assertEqual(len(self.media_info.tracks), 1)
+        assert len(self.media_info.tracks) == 1
 
 
 @pytest.mark.skipif(
@@ -184,24 +187,26 @@ class MediaInfoURLTest(unittest.TestCase):
 
     def test_parse_url(self) -> None:
         media_info = MediaInfo.parse(self.url)
-        self.assertEqual(len(media_info.tracks), 3)
+        assert len(media_info.tracks) == 3
 
 
 class MediaInfoPathlibTest(unittest.TestCase):
     def test_parse_pathlib_path(self) -> None:
         path = pathlib.Path(data_dir) / "sample.mp4"
         media_info = MediaInfo.parse(path)
-        self.assertEqual(len(media_info.tracks), 3)
+        assert len(media_info.tracks) == 3
 
     def test_parse_non_existent_path_pathlib(self) -> None:
         path = pathlib.Path(data_dir) / "this file does not exist"
-        self.assertRaises(FileNotFoundError, MediaInfo.parse, path)
+        with pytest.raises(FileNotFoundError):
+            MediaInfo.parse(path)
 
 
 class MediaInfoTestParseNonExistentFile(unittest.TestCase):
     def test_parse_non_existent_path(self) -> None:
         path = os.path.join(data_dir, "this file does not exist")
-        self.assertRaises(FileNotFoundError, MediaInfo.parse, path)
+        with pytest.raises(FileNotFoundError):
+            MediaInfo.parse(path)
 
 
 class MediaInfoCoverDataTest(unittest.TestCase):
@@ -212,33 +217,34 @@ class MediaInfoCoverDataTest(unittest.TestCase):
         self.no_cover_mi = MediaInfo.parse(os.path.join(data_dir, "sample_with_cover.mp3"))
 
     def test_parse_cover_data(self) -> None:
-        self.assertEqual(
-            self.cover_mi.tracks[0].cover_data,
+        expected = (
             "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACXBIWXMAAAAAAA"
-            "AAAQCEeRdzAAAADUlEQVR4nGP4x8DwHwAE/AH+QSRCQgAAAABJRU5ErkJggg==",
+            "AAAQCEeRdzAAAADUlEQVR4nGP4x8DwHwAE/AH+QSRCQgAAAABJRU5ErkJggg=="
         )
+        assert self.cover_mi.tracks[0].cover_data == expected
 
     def test_parse_no_cover_data(self) -> None:
         lib_version_str, lib_version = _get_library_version()
         if lib_version < (18, 3):
             pytest.skip(
                 "The Cover_Data option is not supported by this library version "
-                "(v{} detected, v18.03 required)".format(lib_version_str)
+                f"(v{lib_version_str} detected, v18.03 required)"
             )
-        self.assertEqual(self.no_cover_mi.tracks[0].cover_data, None)
+        assert self.no_cover_mi.tracks[0].cover_data is None
 
 
 class MediaInfoTrackParsingTest(unittest.TestCase):
     def test_track_parsing(self) -> None:
         media_info = MediaInfo.parse(os.path.join(data_dir, "issue55.flv"))
-        self.assertEqual(len(media_info.tracks), 2)
+        assert len(media_info.tracks) == 2
 
 
 class MediaInfoRuntimeErrorTest(unittest.TestCase):
     def test_parse_invalid_url(self) -> None:
         # This is the easiest way to cause a parsing error
         # since non-existent files return a different exception
-        self.assertRaises(RuntimeError, MediaInfo.parse, "unsupportedscheme://")
+        with pytest.raises(RuntimeError):
+            MediaInfo.parse("unsupportedscheme://")
 
 
 class MediaInfoSlowParseTest(unittest.TestCase):
@@ -248,7 +254,7 @@ class MediaInfoSlowParseTest(unittest.TestCase):
         )
 
     def test_slow_parse_speed(self) -> None:
-        self.assertEqual(self.media_info.tracks[2].stream_size, "3353 / 45")
+        assert self.media_info.tracks[2].stream_size == "3353 / 45"
 
 
 class MediaInfoEqTest(unittest.TestCase):
@@ -258,16 +264,16 @@ class MediaInfoEqTest(unittest.TestCase):
         self.mp4_mi = MediaInfo.parse(os.path.join(data_dir, "sample.mp4"))
 
     def test_eq(self) -> None:
-        self.assertEqual(self.mp3_mi.tracks[0], self.mp3_other_mi.tracks[0])
-        self.assertEqual(self.mp3_mi, self.mp3_other_mi)
-        self.assertNotEqual(self.mp3_mi.tracks[0], self.mp4_mi.tracks[0])
-        self.assertNotEqual(self.mp3_mi, self.mp4_mi)
+        assert self.mp3_mi.tracks[0] == self.mp3_other_mi.tracks[0]
+        assert self.mp3_mi == self.mp3_other_mi
+        assert self.mp3_mi.tracks[0] != self.mp4_mi.tracks[0]
+        assert self.mp3_mi != self.mp4_mi
 
     def test_pickle_unpickle(self) -> None:
         pickled_track = pickle.dumps(self.mp4_mi.tracks[0])
-        self.assertEqual(self.mp4_mi.tracks[0], pickle.loads(pickled_track))
+        assert self.mp4_mi.tracks[0] == pickle.loads(pickled_track)
         pickled_mi = pickle.dumps(self.mp4_mi)
-        self.assertEqual(self.mp4_mi, pickle.loads(pickled_mi))
+        assert self.mp4_mi == pickle.loads(pickled_mi)
 
 
 class MediaInfoLegacyStreamDisplayTest(unittest.TestCase):
@@ -278,8 +284,8 @@ class MediaInfoLegacyStreamDisplayTest(unittest.TestCase):
         )
 
     def test_legacy_stream_display(self) -> None:
-        self.assertEqual(self.media_info.tracks[1].channel_s, 2)
-        self.assertEqual(self.legacy_mi.tracks[1].channel_s, "2 / 1 / 1")
+        assert self.media_info.tracks[1].channel_s == 2
+        assert self.legacy_mi.tracks[1].channel_s == "2 / 1 / 1"
 
 
 class MediaInfoOptionsTest(unittest.TestCase):
@@ -288,7 +294,7 @@ class MediaInfoOptionsTest(unittest.TestCase):
         if lib_version < (19, 9):
             pytest.skip(
                 "The Reset option is not supported by this library version "
-                "(v{} detected, v19.09 required)".format(lib_version_str)
+                f"(v{lib_version_str} detected, v19.09 required)"
             )
         self.raw_language_mi = MediaInfo.parse(
             os.path.join(data_dir, "sample.mkv"),
@@ -302,8 +308,8 @@ class MediaInfoOptionsTest(unittest.TestCase):
         )
 
     def test_mediainfo_options(self) -> None:
-        self.assertEqual(self.normal_mi.tracks[1].other_language[0], "English")
-        self.assertEqual(self.raw_language_mi.tracks[1].language, "en")
+        assert self.normal_mi.tracks[1].other_language[0] == "English"
+        assert self.raw_language_mi.tracks[1].language == "en"
 
 
 # Unittests can't be parametrized
@@ -314,7 +320,7 @@ def test_thread_safety(test_file: str) -> None:
     if lib_version < (20, 3):
         pytest.skip(
             "This version of the library is not thread-safe "
-            "(v{} detected, v20.03 required)".format(lib_version_str)
+            f"(v{lib_version_str} detected, v20.03 required)"
         )
     expected_result = MediaInfo.parse(os.path.join(data_dir, test_file))
     results = []
@@ -325,7 +331,7 @@ def test_thread_safety(test_file: str) -> None:
             result = MediaInfo.parse(os.path.join(data_dir, test_file))
             with lock:
                 results.append(result)
-        except Exception:  # pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except  # noqa: BLE001
             pass
 
     threads = []
@@ -363,24 +369,24 @@ def test_filelike_returns_the_same(test_file: str) -> None:
 class MediaInfoOutputTest(unittest.TestCase):
     def test_text_output(self) -> None:
         media_info = MediaInfo.parse(os.path.join(data_dir, "sample.mp4"), output="")
-        self.assertRegex(media_info, r"Stream size\s+: 373836\b")
+        assert re.search(r"Stream size\s+: 373836\b", media_info)
 
     def test_json_output(self) -> None:
         lib_version_str, lib_version = _get_library_version()
         if lib_version < (18, 3):
             pytest.skip(
                 "This version of the library does not support JSON output "
-                "(v{} detected, v18.03 required)".format(lib_version_str)
+                f"(v{lib_version_str} detected, v18.03 required)"
             )
         media_info = MediaInfo.parse(os.path.join(data_dir, "sample.mp4"), output="JSON")
         parsed = json.loads(media_info)
-        self.assertEqual(parsed["media"]["track"][0]["FileSize"], "404567")
+        assert parsed["media"]["track"][0]["FileSize"] == "404567"
 
     def test_parameter_output(self) -> None:
         media_info = MediaInfo.parse(
             os.path.join(data_dir, "sample.mp4"), output="General;%FileSize%"
         )
-        self.assertEqual(media_info, "404567")
+        assert media_info == "404567"
 
 
 class MediaInfoTrackShortcutsTests(unittest.TestCase):
@@ -392,32 +398,32 @@ class MediaInfoTrackShortcutsTests(unittest.TestCase):
             self.mi_other = MediaInfo(f.read())
 
     def test_empty_list(self) -> None:
-        self.assertEqual(self.mi_audio.text_tracks, [])
+        assert self.mi_audio.text_tracks == []
 
     def test_general_tracks(self) -> None:
-        self.assertEqual(len(self.mi_audio.general_tracks), 1)
-        self.assertIsNotNone(self.mi_audio.general_tracks[0].file_name)
+        assert len(self.mi_audio.general_tracks) == 1
+        assert self.mi_audio.general_tracks[0].file_name is not None
 
     def test_video_tracks(self) -> None:
-        self.assertEqual(len(self.mi_audio.video_tracks), 1)
-        self.assertIsNotNone(self.mi_audio.video_tracks[0].display_aspect_ratio)
+        assert len(self.mi_audio.video_tracks) == 1
+        assert self.mi_audio.video_tracks[0].display_aspect_ratio is not None
 
     def test_audio_tracks(self) -> None:
-        self.assertEqual(len(self.mi_audio.audio_tracks), 1)
-        self.assertIsNotNone(self.mi_audio.audio_tracks[0].sampling_rate)
+        assert len(self.mi_audio.audio_tracks) == 1
+        assert self.mi_audio.audio_tracks[0].sampling_rate is not None
 
     def test_text_tracks(self) -> None:
-        self.assertEqual(len(self.mi_text.text_tracks), 1)
-        self.assertEqual(self.mi_text.text_tracks[0].kind_of_stream, "Text")
+        assert len(self.mi_text.text_tracks) == 1
+        assert self.mi_text.text_tracks[0].kind_of_stream == "Text"
 
     def test_other_tracks(self) -> None:
-        self.assertEqual(len(self.mi_other.other_tracks), 2)
-        self.assertEqual(self.mi_other.other_tracks[0].type, "Time code")
+        assert len(self.mi_other.other_tracks) == 2
+        assert self.mi_other.other_tracks[0].type == "Time code"
 
     def test_image_tracks(self) -> None:
-        self.assertEqual(len(self.mi_image.image_tracks), 1)
-        self.assertEqual(self.mi_image.image_tracks[0].width, 1)
+        assert len(self.mi_image.image_tracks) == 1
+        assert self.mi_image.image_tracks[0].width == 1
 
     def test_menu_tracks(self) -> None:
-        self.assertEqual(len(self.mi_text.menu_tracks), 1)
-        self.assertEqual(self.mi_text.menu_tracks[0].kind_of_stream, "Menu")
+        assert len(self.mi_text.menu_tracks) == 1
+        assert self.mi_text.menu_tracks[0].kind_of_stream == "Menu"

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,10 @@ setenv =
 [testenv:mypy]
 deps =
   mypy
+  requests
+  types-requests
+  tomlkit
+  wheel>=0.44
   pytest
 commands =
   mypy --strict src tests scripts

--- a/tox.ini
+++ b/tox.ini
@@ -6,17 +6,13 @@ envlist =
   py312
   py313
   pypy3
-  black
-  flake8
-  isort
+  pre-commit
   mypy
-  pylint
 
 [testenv]
 deps =
   pytest
   pytest-xdist
-  setuptools_scm
 commands =
   pytest {posargs:-n auto}
 
@@ -24,34 +20,25 @@ commands =
 deps =
   alabaster
   myst-parser
-  setuptools_scm
   sphinx
 commands =
   sphinx-build -W --keep-going --color -b html docs docs/_build
   sphinx-build -W --keep-going --color -b linkcheck docs docs/_build
 
-[testenv:black]
-deps =
-  black
-commands = black --line-length 100 --check --diff src tests scripts
-
-[testenv:flake8]
-deps = flake8
-commands = flake8 --max-line-length 100 src tests
-
-[testenv:isort]
-deps = isort
-commands = isort --check src tests scripts
-
-[testenv:pylint]
-deps =
-  pylint
-  pytest
-commands = pylint src/pymediainfo/ tests/test_pymediainfo.py
+[testenv:pre-commit]
+description =
+    run pre-commit-defined linters under `{basepython}`
+skip_install = true
+basepython = python3
+deps = pre-commit>=2.9.3
+commands = pre-commit run --all-files --show-diff-on-failure {posargs:}
+setenv =
+    # pre-commit and tools it launches are not clean of this warning.
+    PYTHONWARNDEFAULTENCODING=
 
 [testenv:mypy]
 deps =
   mypy
   pytest
 commands =
-  mypy --strict src tests
+  mypy --strict src tests scripts


### PR DESCRIPTION
Replace isort, black, pylint, flake8 by `ruff`.
Add `typos` to correct for misspelled words.

Then use `pre-commit` to start the linter. `pre-commit` can be installed locally, so the linter is run before every commit to ensure the code is always clean.

I also added two changes that were mentioned in other issues:
 - remove the `setuptools_scm` dependency in the docs and use `importlib.metadata`
 - remove the `_normalize_filename` static method to used `os.fspath` instead. Also remove the tests associated to it.
 - the rest of the changes in `src/pymediainfo/__init__.py` are ruff recommendations.

(ruff still shows errors in `scripts/download_library.py` that I didn't correct because it would conflict with the changes of PR #144)